### PR TITLE
Allow branch protection to default to using the default branch

### DIFF
--- a/profiles/github/branch-protection.yaml
+++ b/profiles/github/branch-protection.yaml
@@ -5,65 +5,65 @@ type: profile
 name: branch-protection-github-profile
 context:
   provider: github
-alert: "on"
+alert: "off"
 remediate: "off"
 repository:
   - type: branch_protection_enabled
     params:
-      branch: main
+      branch: ""
     def: {}
   - type: branch_protection_allow_deletions
     params:
-      branch: main
+      branch: ""
     def:
       allow_deletions: false
   - type: branch_protection_allow_force_pushes
     params:
-      branch: main
+      branch: ""
     def:
       allow_force_pushes: false
   - type: branch_protection_enforce_admins
     params:
-      branch: main
+      branch: ""
     def:
       enforce_admins: true
   - type: branch_protection_lock_branch
     params:
-      branch: main
+      branch: ""
     def:
       lock_branch: false
   - type: branch_protection_require_conversation_resolution
     params:
-      branch: main
+      branch: ""
     def:
       required_conversation_resolution: false
   - type: branch_protection_require_pull_request_approving_review_count
     params:
-      branch: main
+      branch: ""
     def:
       required_approving_review_count: 1
   - type: branch_protection_require_pull_request_code_owners_review
     params:
-      branch: main
+      branch: ""
     def:
       require_code_owner_reviews: false
   - type: branch_protection_require_pull_request_dismiss_stale_reviews
     params:
-      branch: main
+      branch: ""
     def:
       dismiss_stale_reviews: true
   - type: branch_protection_require_pull_request_last_push_approval
     params:
-      branch: main
+      branch: ""
     def:
       require_last_push_approval: true
   - type: branch_protection_require_pull_requests
     params:
-      branch: main
+      branch: ""
     def:
       required_pull_request_reviews: true
   - type: branch_protection_require_signatures
     params:
-      branch: main
+      branch: ""
     def:
       required_signatures: false

--- a/rule-types/github/branch_protection_allow_deletions.yaml
+++ b/rule-types/github/branch_protection_allow_deletions.yaml
@@ -20,7 +20,7 @@ def:
     properties:
       branch:
         type: string
-        description: "The name of the branch to check."
+        description: "The name of the branch to check. If left empty, the default branch will be used."
     required:
       - branch
   # Defines the schema for writing a rule with this rule being checked
@@ -38,7 +38,7 @@ def:
       # for each repository in the organization, we use a template that
       # will be evaluated for each repository. The structure to use is the
       # protobuf structure for the entity that is being evaluated.
-      endpoint: '/repos/{{.Entity.Owner}}/{{.Entity.Name}}/branches/{{ index .Params "branch" }}/protection'
+      endpoint: '{{ $branch_param := index .Params "branch" }}/repos/{{.Entity.Owner}}/{{.Entity.Name}}/branches/{{if ne $branch_param "" }}{{ $branch_param }}{{ else }}{{ .Entity.DefaultBranch }}{{ end }}/protection'
       # This is the method to use to retrieve the data. It should already default to JSON
       parse: json
       fallback:

--- a/rule-types/github/branch_protection_allow_force_pushes.yaml
+++ b/rule-types/github/branch_protection_allow_force_pushes.yaml
@@ -20,7 +20,7 @@ def:
     properties:
       branch:
         type: string
-        description: "The name of the branch to check."
+        description: "The name of the branch to check. If left empty, the default branch will be used."
     required:
       - branch
   # Defines the schema for writing a rule with this rule being checked
@@ -39,7 +39,7 @@ def:
       # for each repository in the organization, we use a template that
       # will be evaluated for each repository. The structure to use is the
       # protobuf structure for the entity that is being evaluated.
-      endpoint: '/repos/{{.Entity.Owner}}/{{.Entity.Name}}/branches/{{ index .Params "branch" }}/protection'
+      endpoint: '{{ $branch_param := index .Params "branch" }}/repos/{{.Entity.Owner}}/{{.Entity.Name}}/branches/{{if ne $branch_param "" }}{{ $branch_param }}{{ else }}{{ .Entity.DefaultBranch }}{{ end }}/protection'
       # This is the method to use to retrieve the data. It should already default to JSON
       parse: json
       fallback:

--- a/rule-types/github/branch_protection_allow_fork_syncing.yaml
+++ b/rule-types/github/branch_protection_allow_fork_syncing.yaml
@@ -20,7 +20,7 @@ def:
     properties:
       branch:
         type: string
-        description: "The name of the branch to check."
+        description: "The name of the branch to check. If left empty, the default branch will be used."
     required:
       - branch
   # Defines the schema for writing a rule with this rule being checked
@@ -39,7 +39,7 @@ def:
       # for each repository in the organization, we use a template that
       # will be evaluated for each repository. The structure to use is the
       # protobuf structure for the entity that is being evaluated.
-      endpoint: '/repos/{{.Entity.Owner}}/{{.Entity.Name}}/branches/{{ index .Params "branch" }}/protection'
+      endpoint: '{{ $branch_param := index .Params "branch" }}/repos/{{.Entity.Owner}}/{{.Entity.Name}}/branches/{{if ne $branch_param "" }}{{ $branch_param }}{{ else }}{{ .Entity.DefaultBranch }}{{ end }}/protection'
       # This is the method to use to retrieve the data. It should already default to JSON
       parse: json
       fallback:

--- a/rule-types/github/branch_protection_enabled.yaml
+++ b/rule-types/github/branch_protection_enabled.yaml
@@ -22,7 +22,7 @@ def:
     properties:
       branch:
         type: string
-        description: "The name of the branch to check."
+        description: "The name of the branch to check. If left empty, the default branch will be used."
     required:
       - branch
   rule_schema: {}
@@ -34,7 +34,7 @@ def:
       # for each repository in the organization, we use a template that
       # will be evaluated for each repository. The structure to use is the
       # protobuf structure for the entity that is being evaluated.
-      endpoint: '/repos/{{.Entity.Owner}}/{{.Entity.Name}}/branches/{{ index .Params "branch" }}/protection'
+      endpoint: '{{ $branch_param := index .Params "branch" }}/repos/{{.Entity.Owner}}/{{.Entity.Name}}/branches/{{if ne $branch_param "" }}{{ $branch_param }}{{ else }}{{ .Entity.DefaultBranch }}{{ end }}/protection'
       # This is the method to use to retrieve the data. It should already default to JSON
       parse: json
       fallback:

--- a/rule-types/github/branch_protection_enforce_admins.yaml
+++ b/rule-types/github/branch_protection_enforce_admins.yaml
@@ -20,7 +20,7 @@ def:
     properties:
       branch:
         type: string
-        description: "The name of the branch to check."
+        description: "The name of the branch to check. If left empty, the default branch will be used."
     required:
       - branch
   # Defines the schema for writing a rule with this rule being checked
@@ -38,7 +38,7 @@ def:
       # for each repository in the organization, we use a template that
       # will be evaluated for each repository. The structure to use is the
       # protobuf structure for the entity that is being evaluated.
-      endpoint: '/repos/{{.Entity.Owner}}/{{.Entity.Name}}/branches/{{ index .Params "branch" }}/protection'
+      endpoint: '{{ $branch_param := index .Params "branch" }}/repos/{{.Entity.Owner}}/{{.Entity.Name}}/branches/{{if ne $branch_param "" }}{{ $branch_param }}{{ else }}{{ .Entity.DefaultBranch }}{{ end }}/protection'
       # This is the method to use to retrieve the data. It should already default to JSON
       parse: json
       fallback:

--- a/rule-types/github/branch_protection_lock_branch.yaml
+++ b/rule-types/github/branch_protection_lock_branch.yaml
@@ -20,7 +20,7 @@ def:
     properties:
       branch:
         type: string
-        description: "The name of the branch to check."
+        description: "The name of the branch to check. If left empty, the default branch will be used."
     required:
       - branch
   # Defines the schema for writing a rule with this rule being checked
@@ -39,7 +39,7 @@ def:
       # for each repository in the organization, we use a template that
       # will be evaluated for each repository. The structure to use is the
       # protobuf structure for the entity that is being evaluated.
-      endpoint: '/repos/{{.Entity.Owner}}/{{.Entity.Name}}/branches/{{ index .Params "branch" }}/protection'
+      endpoint: '{{ $branch_param := index .Params "branch" }}/repos/{{.Entity.Owner}}/{{.Entity.Name}}/branches/{{if ne $branch_param "" }}{{ $branch_param }}{{ else }}{{ .Entity.DefaultBranch }}{{ end }}/protection'
       # This is the method to use to retrieve the data. It should already default to JSON
       parse: json
       fallback:

--- a/rule-types/github/branch_protection_require_conversation_resolution.yaml
+++ b/rule-types/github/branch_protection_require_conversation_resolution.yaml
@@ -20,7 +20,7 @@ def:
     properties:
       branch:
         type: string
-        description: "The name of the branch to check."
+        description: "The name of the branch to check. If left empty, the default branch will be used."
     required:
       - branch
   # Defines the schema for writing a rule with this rule being checked
@@ -39,7 +39,7 @@ def:
       # for each repository in the organization, we use a template that
       # will be evaluated for each repository. The structure to use is the
       # protobuf structure for the entity that is being evaluated.
-      endpoint: '/repos/{{.Entity.Owner}}/{{.Entity.Name}}/branches/{{ index .Params "branch" }}/protection'
+      endpoint: '{{ $branch_param := index .Params "branch" }}/repos/{{.Entity.Owner}}/{{.Entity.Name}}/branches/{{if ne $branch_param "" }}{{ $branch_param }}{{ else }}{{ .Entity.DefaultBranch }}{{ end }}/protection'
       # This is the method to use to retrieve the data. It should already default to JSON
       parse: json
       fallback:

--- a/rule-types/github/branch_protection_require_linear_history.yaml
+++ b/rule-types/github/branch_protection_require_linear_history.yaml
@@ -20,7 +20,7 @@ def:
     properties:
       branch:
         type: string
-        description: "The name of the branch to check."
+        description: "The name of the branch to check. If left empty, the default branch will be used."
     required:
       - branch
   # Defines the schema for writing a rule with this rule being checked
@@ -39,7 +39,7 @@ def:
       # for each repository in the organization, we use a template that
       # will be evaluated for each repository. The structure to use is the
       # protobuf structure for the entity that is being evaluated.
-      endpoint: '/repos/{{.Entity.Owner}}/{{.Entity.Name}}/branches/{{ index .Params "branch" }}/protection'
+      endpoint: '{{ $branch_param := index .Params "branch" }}/repos/{{.Entity.Owner}}/{{.Entity.Name}}/branches/{{if ne $branch_param "" }}{{ $branch_param }}{{ else }}{{ .Entity.DefaultBranch }}{{ end }}/protection'
       # This is the method to use to retrieve the data. It should already default to JSON
       parse: json
       fallback:

--- a/rule-types/github/branch_protection_require_pull_request_approving_review_count.yaml
+++ b/rule-types/github/branch_protection_require_pull_request_approving_review_count.yaml
@@ -20,7 +20,7 @@ def:
     properties:
       branch:
         type: string
-        description: "The name of the branch to check."
+        description: "The name of the branch to check. If left empty, the default branch will be used."
     required:
       - branch
   # Defines the schema for writing a rule with this rule being checked
@@ -39,7 +39,7 @@ def:
       # for each repository in the organization, we use a template that
       # will be evaluated for each repository. The structure to use is the
       # protobuf structure for the entity that is being evaluated.
-      endpoint: '/repos/{{.Entity.Owner}}/{{.Entity.Name}}/branches/{{ index .Params "branch" }}/protection'
+      endpoint: '{{ $branch_param := index .Params "branch" }}/repos/{{.Entity.Owner}}/{{.Entity.Name}}/branches/{{if ne $branch_param "" }}{{ $branch_param }}{{ else }}{{ .Entity.DefaultBranch }}{{ end }}/protection'
       # This is the method to use to retrieve the data. It should already default to JSON
       parse: json
       fallback:

--- a/rule-types/github/branch_protection_require_pull_request_code_owners_review.yaml
+++ b/rule-types/github/branch_protection_require_pull_request_code_owners_review.yaml
@@ -20,7 +20,7 @@ def:
     properties:
       branch:
         type: string
-        description: "The name of the branch to check."
+        description: "The name of the branch to check. If left empty, the default branch will be used."
     required:
       - branch
   # Defines the schema for writing a rule with this rule being checked
@@ -39,7 +39,7 @@ def:
       # for each repository in the organization, we use a template that
       # will be evaluated for each repository. The structure to use is the
       # protobuf structure for the entity that is being evaluated.
-      endpoint: '/repos/{{.Entity.Owner}}/{{.Entity.Name}}/branches/{{ index .Params "branch" }}/protection'
+      endpoint: '{{ $branch_param := index .Params "branch" }}/repos/{{.Entity.Owner}}/{{.Entity.Name}}/branches/{{if ne $branch_param "" }}{{ $branch_param }}{{ else }}{{ .Entity.DefaultBranch }}{{ end }}/protection'
       # This is the method to use to retrieve the data. It should already default to JSON
       parse: json
       fallback:

--- a/rule-types/github/branch_protection_require_pull_request_dismiss_stale_reviews.yaml
+++ b/rule-types/github/branch_protection_require_pull_request_dismiss_stale_reviews.yaml
@@ -20,7 +20,7 @@ def:
     properties:
       branch:
         type: string
-        description: "The name of the branch to check."
+        description: "The name of the branch to check. If left empty, the default branch will be used."
     required:
       - branch
   # Defines the schema for writing a rule with this rule being checked
@@ -39,7 +39,7 @@ def:
       # for each repository in the organization, we use a template that
       # will be evaluated for each repository. The structure to use is the
       # protobuf structure for the entity that is being evaluated.
-      endpoint: '/repos/{{.Entity.Owner}}/{{.Entity.Name}}/branches/{{ index .Params "branch" }}/protection'
+      endpoint: '{{ $branch_param := index .Params "branch" }}/repos/{{.Entity.Owner}}/{{.Entity.Name}}/branches/{{if ne $branch_param "" }}{{ $branch_param }}{{ else }}{{ .Entity.DefaultBranch }}{{ end }}/protection'
       # This is the method to use to retrieve the data. It should already default to JSON
       parse: json
       fallback:

--- a/rule-types/github/branch_protection_require_pull_request_last_push_approval.yaml
+++ b/rule-types/github/branch_protection_require_pull_request_last_push_approval.yaml
@@ -20,7 +20,7 @@ def:
     properties:
       branch:
         type: string
-        description: "The name of the branch to check."
+        description: "The name of the branch to check. If left empty, the default branch will be used."
     required:
       - branch
   # Defines the schema for writing a rule with this rule being checked
@@ -38,7 +38,7 @@ def:
       # for each repository in the organization, we use a template that
       # will be evaluated for each repository. The structure to use is the
       # protobuf structure for the entity that is being evaluated.
-      endpoint: '/repos/{{.Entity.Owner}}/{{.Entity.Name}}/branches/{{ index .Params "branch" }}/protection'
+      endpoint: '{{ $branch_param := index .Params "branch" }}/repos/{{.Entity.Owner}}/{{.Entity.Name}}/branches/{{if ne $branch_param "" }}{{ $branch_param }}{{ else }}{{ .Entity.DefaultBranch }}{{ end }}/protection'
       # This is the method to use to retrieve the data. It should already default to JSON
       parse: json
       fallback:

--- a/rule-types/github/branch_protection_require_pull_requests.yaml
+++ b/rule-types/github/branch_protection_require_pull_requests.yaml
@@ -20,7 +20,7 @@ def:
     properties:
       branch:
         type: string
-        description: "The name of the branch to check."
+        description: "The name of the branch to check. If left empty, the default branch will be used."
     required:
       - branch
   # Defines the schema for writing a rule with this rule being checked
@@ -42,7 +42,7 @@ def:
       # for each repository in the organization, we use a template that
       # will be evaluated for each repository. The structure to use is the
       # protobuf structure for the entity that is being evaluated.
-      endpoint: '/repos/{{.Entity.Owner}}/{{.Entity.Name}}/branches/{{ index .Params "branch" }}/protection'
+      endpoint: '{{ $branch_param := index .Params "branch" }}/repos/{{.Entity.Owner}}/{{.Entity.Name}}/branches/{{if ne $branch_param "" }}{{ $branch_param }}{{ else }}{{ .Entity.DefaultBranch }}{{ end }}/protection'
       # This is the method to use to retrieve the data. It should already default to JSON
       parse: json
       fallback:

--- a/rule-types/github/branch_protection_require_signatures.yaml
+++ b/rule-types/github/branch_protection_require_signatures.yaml
@@ -20,7 +20,7 @@ def:
     properties:
       branch:
         type: string
-        description: "The name of the branch to check."
+        description: "The name of the branch to check. If left empty, the default branch will be used."
     required:
       - branch
   # Defines the schema for writing a rule with this rule being checked
@@ -39,7 +39,7 @@ def:
       # for each repository in the organization, we use a template that
       # will be evaluated for each repository. The structure to use is the
       # protobuf structure for the entity that is being evaluated.
-      endpoint: '/repos/{{.Entity.Owner}}/{{.Entity.Name}}/branches/{{ index .Params "branch" }}/protection'
+      endpoint: '{{ $branch_param := index .Params "branch" }}/repos/{{.Entity.Owner}}/{{.Entity.Name}}/branches/{{if ne $branch_param "" }}{{ $branch_param }}{{ else }}{{ .Entity.DefaultBranch }}{{ end }}/protection'
       # This is the method to use to retrieve the data. It should already default to JSON
       parse: json
       fallback:


### PR DESCRIPTION
If the rule type is not given an explicit branch (the string is empty)
the rule type will use the default branch to check for branch
protection.

Signed-off-by: Juan Antonio Osorio <ozz@stacklok.com>