### PR TITLE
Update CodeQL schedule in sample profiles

### DIFF
--- a/profiles/github/ghas.yaml
+++ b/profiles/github/ghas.yaml
@@ -16,7 +16,7 @@ repository:
   - type: codeql_enabled
     def:
       languages: [go, javascript, typescript, python]
-      schedule_interval: '30 4-6 * * *'
+      schedule_interval: '30 4 * * 0'
   - type: dependabot_configured
     def: 
       package_ecosystem: gomod

--- a/profiles/github/openssf_security_baseline.yaml
+++ b/profiles/github/openssf_security_baseline.yaml
@@ -66,7 +66,7 @@ repository:
   - type: codeql_enabled
     def:
       languages: []
-      schedule_interval: '30 4-6 * * *'
+      schedule_interval: '30 4 * * 0'
 
   # Force two-person review on pull requests before merging
   - type: branch_protection_require_pull_request_approving_review_count

--- a/profiles/github/profile.yaml
+++ b/profiles/github/profile.yaml
@@ -30,7 +30,7 @@ repository:
   - type: codeql_enabled
     def:
       languages: [go, javascript, typescript]
-      schedule_interval: '30 4-6 * * *'
+      schedule_interval: '30 4 * * 0'
   - type: actions_check_pinned_tags
     def:
       exclude: []

--- a/profiles/github/repo_security.yaml
+++ b/profiles/github/repo_security.yaml
@@ -16,4 +16,4 @@ repository:
   - type: codeql_enabled
     def:
       languages: [go, javascript, typescript]
-      schedule_interval: '30 4-6 * * *'
+      schedule_interval: '30 4 * * 0'


### PR DESCRIPTION
Sets the default CodeQL schedule to once a week instead of 3x/day, aligning with GitHub's default frequency.