### PR TITLE
Remove `required` branch from branch protection rules and use default

### DIFF
--- a/rule-types/github/branch_protection_allow_deletions.yaml
+++ b/rule-types/github/branch_protection_allow_deletions.yaml
@@ -29,8 +29,7 @@ def:
       branch:
         type: string
         description: "The name of the branch to check. If left empty, the default branch will be used."
-    required:
-      - branch
+        default: ""
   # Defines the schema for writing a rule with this rule being checked
   rule_schema:
     type: object

--- a/rule-types/github/branch_protection_allow_force_pushes.yaml
+++ b/rule-types/github/branch_protection_allow_force_pushes.yaml
@@ -30,8 +30,7 @@ def:
       branch:
         type: string
         description: "The name of the branch to check. If left empty, the default branch will be used."
-    required:
-      - branch
+        default: ""
   # Defines the schema for writing a rule with this rule being checked
   rule_schema:
     type: object

--- a/rule-types/github/branch_protection_allow_fork_syncing.yaml
+++ b/rule-types/github/branch_protection_allow_fork_syncing.yaml
@@ -30,8 +30,7 @@ def:
       branch:
         type: string
         description: "The name of the branch to check. If left empty, the default branch will be used."
-    required:
-      - branch
+        default: ""
   # Defines the schema for writing a rule with this rule being checked
   rule_schema:
     properties:

--- a/rule-types/github/branch_protection_enabled.yaml
+++ b/rule-types/github/branch_protection_enabled.yaml
@@ -31,8 +31,7 @@ def:
       branch:
         type: string
         description: "The name of the branch to check. If left empty, the default branch will be used."
-    required:
-      - branch
+        default: ""
   rule_schema: {}
   # Defines the configuration for ingesting data relevant for the rule
   ingest:

--- a/rule-types/github/branch_protection_enforce_admins.yaml
+++ b/rule-types/github/branch_protection_enforce_admins.yaml
@@ -27,8 +27,7 @@ def:
       branch:
         type: string
         description: "The name of the branch to check. If left empty, the default branch will be used."
-    required:
-      - branch
+        default: ""
   # Defines the schema for writing a rule with this rule being checked
   rule_schema:
     properties:

--- a/rule-types/github/branch_protection_lock_branch.yaml
+++ b/rule-types/github/branch_protection_lock_branch.yaml
@@ -29,8 +29,7 @@ def:
       branch:
         type: string
         description: "The name of the branch to check. If left empty, the default branch will be used."
-    required:
-      - branch
+        default: ""
   # Defines the schema for writing a rule with this rule being checked
   rule_schema:
     properties:

--- a/rule-types/github/branch_protection_require_conversation_resolution.yaml
+++ b/rule-types/github/branch_protection_require_conversation_resolution.yaml
@@ -31,8 +31,7 @@ def:
       branch:
         type: string
         description: "The name of the branch to check. If left empty, the default branch will be used."
-    required:
-      - branch
+        default: ""
   # Defines the schema for writing a rule with this rule being checked
   rule_schema:
     properties:

--- a/rule-types/github/branch_protection_require_linear_history.yaml
+++ b/rule-types/github/branch_protection_require_linear_history.yaml
@@ -29,8 +29,7 @@ def:
       branch:
         type: string
         description: "The name of the branch to check. If left empty, the default branch will be used."
-    required:
-      - branch
+        default: ""
   # Defines the schema for writing a rule with this rule being checked
   rule_schema:
     properties:

--- a/rule-types/github/branch_protection_require_pull_request_approving_review_count.yaml
+++ b/rule-types/github/branch_protection_require_pull_request_approving_review_count.yaml
@@ -30,8 +30,7 @@ def:
       branch:
         type: string
         description: "The name of the branch to check. If left empty, the default branch will be used."
-    required:
-      - branch
+        default: ""
   # Defines the schema for writing a rule with this rule being checked
   rule_schema:
     properties:

--- a/rule-types/github/branch_protection_require_pull_request_code_owners_review.yaml
+++ b/rule-types/github/branch_protection_require_pull_request_code_owners_review.yaml
@@ -31,8 +31,7 @@ def:
       branch:
         type: string
         description: "The name of the branch to check. If left empty, the default branch will be used."
-    required:
-      - branch
+        default: ""
   # Defines the schema for writing a rule with this rule being checked
   rule_schema:
     properties:

--- a/rule-types/github/branch_protection_require_pull_request_dismiss_stale_reviews.yaml
+++ b/rule-types/github/branch_protection_require_pull_request_dismiss_stale_reviews.yaml
@@ -30,8 +30,7 @@ def:
       branch:
         type: string
         description: "The name of the branch to check. If left empty, the default branch will be used."
-    required:
-      - branch
+        default: ""
   # Defines the schema for writing a rule with this rule being checked
   rule_schema:
     properties:

--- a/rule-types/github/branch_protection_require_pull_request_last_push_approval.yaml
+++ b/rule-types/github/branch_protection_require_pull_request_last_push_approval.yaml
@@ -30,8 +30,7 @@ def:
       branch:
         type: string
         description: "The name of the branch to check. If left empty, the default branch will be used."
-    required:
-      - branch
+        default: ""
   # Defines the schema for writing a rule with this rule being checked
   rule_schema:
     properties:

--- a/rule-types/github/branch_protection_require_pull_requests.yaml
+++ b/rule-types/github/branch_protection_require_pull_requests.yaml
@@ -30,8 +30,7 @@ def:
       branch:
         type: string
         description: "The name of the branch to check. If left empty, the default branch will be used."
-    required:
-      - branch
+        default: ""
   # Defines the schema for writing a rule with this rule being checked
   rule_schema:
     properties:

--- a/rule-types/github/branch_protection_require_signatures.yaml
+++ b/rule-types/github/branch_protection_require_signatures.yaml
@@ -29,8 +29,7 @@ def:
       branch:
         type: string
         description: "The name of the branch to check. If left empty, the default branch will be used."
-    required:
-      - branch
+        default: ""
   # Defines the schema for writing a rule with this rule being checked
   rule_schema:
     type: object


### PR DESCRIPTION
This makes it so that branch protection rules no longer have a
`required` parameter. Instead, this is replaced by a default value of
`""`

Signed-off-by: Juan Antonio Osorio <ozz@stacklok.com>
