### PR TITLE
Fix sonatype datasource name.

### DIFF
--- a/data-sources/sonatype-oss-index.yaml
+++ b/data-sources/sonatype-oss-index.yaml
@@ -1,7 +1,7 @@
 ---
 version: v1
 type: data-source
-name: sonatype_oss_index
+name: sonatype-oss-index
 context: {}
 rest:
   def:


### PR DESCRIPTION
Datasource names are normalized before being passed to REGO, and dashes become underscores.