### PR TITLE
Add OSI and GitHub data sources.

### DIFF
--- a/data-sources/ghapi.yaml
+++ b/data-sources/ghapi.yaml
@@ -1,0 +1,15 @@
+version: v1
+type: data-source
+name: ghapi
+rest:
+  def:
+    license:
+      endpoint: https://api.github.com/repos/{owner}/{repo}/license
+      parse: json
+      input_schema:
+        type: object
+        properties:
+          owner:
+            type: string
+          repo:
+            type: string

--- a/data-sources/osi.yaml
+++ b/data-sources/osi.yaml
@@ -1,0 +1,9 @@
+version: v1
+type: data-source
+name: osi
+rest:
+  def:
+    licenses:
+      endpoint: https://raw.githubusercontent.com/spdx/license-list-data/refs/heads/main/json/licenses.json
+      parse: json
+      input_schema: {}


### PR DESCRIPTION
This change adds two data sources useful to implement OSPS Baseline checks.

OSI data source is pretty simple and static, and can be used to verify if a given license is allowed by either OSI or FSF.

GitHub data source is useful to get the license of a given public repository as detected by GitHub. Note that this currently only works for public repositories.