### PR TITLE
Rename osi DS -> spdx-license-list

### DIFF
--- a/data-sources/spdx-license-list.yaml
+++ b/data-sources/spdx-license-list.yaml
@@ -1,6 +1,6 @@
 version: v1
 type: data-source
-name: osi
+name: "spdx-license-list"
 context: {}
 rest:
   def:


### PR DESCRIPTION
This commit renames the "osi" license list to reference the source of the license data.

/cc @blkt @rdimitrov 

Signed-off-by: Adolfo García Veytia (puerco) <puerco@stacklok.com>
