### PR TITLE
Add rule types to check for Anchore's `scan-action` which calls grype

### DIFF
--- a/rule-types/github/grype_github_action_scan_container_image.test.yaml
+++ b/rule-types/github/grype_github_action_scan_container_image.test.yaml
@@ -1,0 +1,26 @@
+tests:
+  - name: "Should have grype github action enabled"
+    def: {}
+    params: {}
+    expect: "pass"
+    entity: &test-repo
+      type: repository
+      entity:
+        owner: "coolhead"
+        name: "haze-wave"
+    git:
+      repo_base: action_enabled
+  - name: "Action is missing"
+    def: {}
+    params: {}
+    expect: "fail"
+    entity: *test-repo
+    git:
+      repo_base: action_missing
+  - name: "Action is enabled but not for container image scanning"
+    def: {}
+    params: {}
+    expect: "fail"
+    entity: *test-repo
+    git:
+      repo_base: action_enabled_not_for_container_image_scanning

--- a/rule-types/github/grype_github_action_scan_container_image.testdata/action_enabled/.github/workflows/wf.yml
+++ b/rule-types/github/grype_github_action_scan_container_image.testdata/action_enabled/.github/workflows/wf.yml
@@ -1,0 +1,34 @@
+name: Container Security scanning
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+
+      - name: Set up Go
+        uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5
+        with:
+          check-latest: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: build local container
+        uses: docker/build-push-action@v4
+        with:
+          tags: localbuild/testimage:latest
+          push: false
+          load: true
+
+      - name: Scan image
+        uses: anchore/scan-action@v6.0.0
+        with:
+          image: "localbuild/testimage:latest"

--- a/rule-types/github/grype_github_action_scan_container_image.testdata/action_enabled_not_for_container_image_scanning/.github/workflows/wf.yml
+++ b/rule-types/github/grype_github_action_scan_container_image.testdata/action_enabled_not_for_container_image_scanning/.github/workflows/wf.yml
@@ -1,0 +1,19 @@
+name: Repo scanning
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+
+      - name: Scan image
+        uses: anchore/scan-action@v6.0.0
+        with:
+          path: "."

--- a/rule-types/github/grype_github_action_scan_container_image.testdata/action_missing/.github/workflows/wf.yml
+++ b/rule-types/github/grype_github_action_scan_container_image.testdata/action_missing/.github/workflows/wf.yml
@@ -1,0 +1,14 @@
+name: Just checkout
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4

--- a/rule-types/github/grype_github_action_scan_container_image.yaml
+++ b/rule-types/github/grype_github_action_scan_container_image.yaml
@@ -1,0 +1,68 @@
+---
+version: v1
+release_phase: beta
+type: rule-type
+name: grype_github_action_scan_container_image
+display_name: Ensure Grype GitHub Action Scans Container Images
+short_failure_message: Grype GitHub Action is not enabled for container image scanning.
+severity:
+  value: medium
+context:
+  provider: github
+description: |
+  This rule checks whether the Grype GitHub Action is enabled to scan container images for vulnerabilities.
+  Grype, a vulnerability scanner from Anchore, provides a robust mechanism to identify issues in container images. 
+  Implementing this action helps maintain secure and compliant workflows for containerized applications.
+
+guidance: |
+  Enable the Grype GitHub Action in your GitHub Actions workflow to scan container images for vulnerabilities. 
+  
+  You can add the Grype action to your workflow using the following configuration:
+
+  ```yaml
+  - name: Scan image
+    uses: anchore/scan-action@v6.0.0
+    with:
+      image: "<image-reference>"
+  ```
+
+  For more details, refer to the [Grype action documentation](https://github.com/anchore/scan-action).
+
+def:
+  in_entity: repository
+  rule_schema: {}
+  ingest:
+    type: git
+    git: {}
+  eval:
+    type: rego
+    rego:
+      type: deny-by-default
+      def: |
+        package minder
+
+        default allow := false
+        default message := "Grype GitHub Action is not enabled for container image scanning."
+
+        allow {
+            # List all workflows
+            workflows := file.ls("./.github/workflows")
+
+            # Read all workflows
+            some w
+            workflowstr := file.read(workflows[w])
+
+            workflow := yaml.unmarshal(workflowstr)
+
+            # Iterate jobs
+            job := workflow.jobs[_]
+
+            # Iterate steps
+            step := job.steps[_]
+
+            # Check if the step is a Grype action
+            startswith(step.uses, "anchore/scan-action@")
+        
+            # Check that the "with.image" field is set
+            step["with"]["image"] != ""
+        }

--- a/rule-types/github/grype_github_action_scan_repo.test.yaml
+++ b/rule-types/github/grype_github_action_scan_repo.test.yaml
@@ -1,0 +1,26 @@
+tests:
+  - name: "Should have grype github action enabled"
+    def: {}
+    params: {}
+    expect: "pass"
+    entity: &test-repo
+      type: repository
+      entity:
+        owner: "coolhead"
+        name: "haze-wave"
+    git:
+      repo_base: action_enabled
+  - name: "Action is missing"
+    def: {}
+    params: {}
+    expect: "fail"
+    entity: *test-repo
+    git:
+      repo_base: action_missing
+  - name: "Action is enabled but not for repo scanning"
+    def: {}
+    params: {}
+    expect: "fail"
+    entity: *test-repo
+    git:
+      repo_base: action_enabled_not_for_repo_scanning

--- a/rule-types/github/grype_github_action_scan_repo.testdata/action_enabled/.github/workflows/wf.yml
+++ b/rule-types/github/grype_github_action_scan_repo.testdata/action_enabled/.github/workflows/wf.yml
@@ -1,0 +1,19 @@
+name: Repo scanning
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+
+      - name: Scan image
+        uses: anchore/scan-action@v6.0.0
+        with:
+          path: "."

--- a/rule-types/github/grype_github_action_scan_repo.testdata/action_enabled_not_for_repo_scanning/.github/workflows/wf.yml
+++ b/rule-types/github/grype_github_action_scan_repo.testdata/action_enabled_not_for_repo_scanning/.github/workflows/wf.yml
@@ -1,0 +1,34 @@
+name: Container Security scanning
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+
+      - name: Set up Go
+        uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5
+        with:
+          check-latest: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: build local container
+        uses: docker/build-push-action@v4
+        with:
+          tags: localbuild/testimage:latest
+          push: false
+          load: true
+
+      - name: Scan image
+        uses: anchore/scan-action@v6.0.0
+        with:
+          image: "localbuild/testimage:latest"

--- a/rule-types/github/grype_github_action_scan_repo.testdata/action_missing/.github/workflows/wf.yml
+++ b/rule-types/github/grype_github_action_scan_repo.testdata/action_missing/.github/workflows/wf.yml
@@ -1,0 +1,14 @@
+name: Just checkout
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4

--- a/rule-types/github/grype_github_action_scan_repo.yaml
+++ b/rule-types/github/grype_github_action_scan_repo.yaml
@@ -1,0 +1,109 @@
+---
+version: v1
+release_phase: beta
+type: rule-type
+name: grype_github_action_scan_repo
+display_name: Ensure Grype GitHub Action Scans Repository
+short_failure_message: Grype GitHub Action is not enabled for repository scanning.
+severity:
+  value: medium
+context:
+  provider: github
+description: |
+  This rule checks whether the Grype GitHub Action is enabled to scan the repository for vulnerabilities.
+  
+  Grype, a vulnerability scanner from Anchore, provides a robust mechanism to identify vulnerabilities.
+  Implementing this action helps maintain secure and compliant dependencies for applications.
+
+guidance: |
+  Enable the Grype GitHub Action in your GitHub Actions workflow to scan repositories for vulnerabilities. 
+  
+  You can add the Grype action to your workflow using the following configuration:
+
+  ```yaml
+  - name: Scan image
+    uses: anchore/scan-action@v6.0.0
+    with:
+      path: "."
+  ```
+
+  For more details, refer to the [Grype action documentation](https://github.com/anchore/scan-action).
+
+def:
+  in_entity: repository
+  rule_schema: {}
+  ingest:
+    type: git
+    git: {}
+  eval:
+    type: rego
+    rego:
+      type: deny-by-default
+      def: |
+        package minder
+
+        default allow := false
+        default message := "Grype GitHub Action is not enabled for repository scanning."
+
+        allow {
+            # List all workflows
+            workflows := file.ls("./.github/workflows")
+
+            # Read all workflows
+            some w
+            workflowstr := file.read(workflows[w])
+
+            workflow := yaml.unmarshal(workflowstr)
+
+            # Iterate jobs
+            job := workflow.jobs[_]
+
+            # Iterate steps
+            step := job.steps[_]
+
+            # Check if the step is a Grype action
+            startswith(step.uses, "anchore/scan-action@")
+        
+            # Check that the "with.path" field is set
+            step["with"]["path"] != ""
+        }
+  remediate:
+    type: pull_request
+    pull_request:
+      title: "Add Grypo repository scanning configuration"
+      body: |
+        This is a Minder automated pull request.
+        
+        This pull request adds a Grype GitHub Action workflow to the repository.
+        
+        For more information, see https://github.com/anchore/scan-action
+      contents:
+        - path: .github/workflows/grype-repo-scan.yml
+          action: replace
+          content: |
+            name: "Grype Repository Scan"
+
+            on:
+              workflow_dispatch:
+              pull_request:
+              schedule:
+                - cron: '{{ .Profile.schedule_interval }}'
+
+            jobs:
+              repo-scan:
+                name: Scan
+                runs-on: 'ubuntu-latest'
+                permissions:
+                  actions: read
+                  contents: read
+
+                steps:
+                  - name: Checkout repository
+                    uses: actions/checkout@v4
+
+                  - name: Scan current project
+                    uses: anchore/scan-action@v6.0.0
+                    with:
+                      path: "."
+                      fail-build: true
+                      severity-cutoff: "high"


### PR DESCRIPTION
This ensures that folks do container or repo scanning and uses the
Grype tool for the job

Signed-off-by: Juan Antonio Osorio <ozz@stacklok.com>
