### PR TITLE
Add `permissive_license` rule type.

### DIFF
--- a/data-sources/spdx.yaml
+++ b/data-sources/spdx.yaml
@@ -1,6 +1,6 @@
 version: v1
 type: data-source
-name: osi
+name: spdx
 context: {}
 rest:
   def:

--- a/rule-types/github/permissive_license.yaml
+++ b/rule-types/github/permissive_license.yaml
@@ -19,11 +19,22 @@ def:
   in_entity: repository
   rule_schema: {}
   ingest:
-    type: git
+    type: rest
+    rest:
+      # This is the path to the data source. Given that this will evaluate
+      # for each repository in the organization, we use a template that
+      # will be evaluated for each repository. The structure to use is the
+      # protobuf structure for the entity that is being evaluated.
+      endpoint: '/repos/{{.Entity.Owner}}/{{.Entity.Name}}/license'
+      # This is the method to use to retrieve the data. It should already default to JSON
+      parse: json
+      fallback:
+        - http_code: 404
+          body: |
+            {"http_status": 404, "message": "License details not found}
   eval:
     type: rego
     data_sources:
-      - name: ghapi
       - name: spdx
     rego:
       type: constraints
@@ -34,11 +45,7 @@ def:
         import future.keywords.if
 
         violations[{"msg": msg}] {
-          owner := input.properties["github/repo_owner"]
-          repo := input.properties["github/repo_name"]
-
-          resp := minder.datasource.ghapi.license({"owner": owner, "repo": repo})
-          license := resp.body.license.spdx_id
+          license := input.ingested.license.spdx_id
 
           resp2 := minder.datasource.spdx.licenses({})
           licenses := resp2.body.licenses
@@ -49,5 +56,5 @@ def:
           count(approved_licenses) != 0
           license != null
           not license in approved_licenses
-          msg := sprintf("License %s of repo %s/%s is not OSI/FSF approved", [license, owner, repo])
+          msg := sprintf("License %s is not OSI/FSF approved", [license])
         }

--- a/rule-types/github/permissive_license.yaml
+++ b/rule-types/github/permissive_license.yaml
@@ -1,0 +1,53 @@
+version: v1
+release_phase: alpha
+type: rule-type
+name: permissive_license
+display_name: License meets the OSI or the FSF definition
+short_failure_message: License does not meet OSI or FSF definition
+severity:
+  value: info
+context:
+  provider: github
+description: |
+  Ensure that the project’s source code is distributed under a
+  recognized and legally enforceable open source software license.
+guidance: |
+  Ensure that the project’s source code is distributed under a
+  recognized and legally enforceable open source software license,
+  providing clarity on how the code can be used and shared by others.
+def:
+  in_entity: repository
+  rule_schema: {}
+  ingest:
+    type: git
+  eval:
+    type: rego
+    data_sources:
+      - name: ghapi
+      - name: spdx
+    rego:
+      type: constraints
+      def: |
+        package minder
+
+        import future.keywords.every
+        import future.keywords.if
+
+        violations[{"msg": msg}] {
+          owner := input.properties["github/repo_owner"]
+          repo := input.properties["github/repo_name"]
+
+          resp := minder.datasource.ghapi.license({"owner": owner, "repo": repo})
+          license := resp.body.license.spdx_id
+
+          resp2 := minder.datasource.spdx.licenses({})
+          licenses := resp2.body.licenses
+          osi := { l.licenseId | l := licenses[_]; l.isOsiApproved }
+          fsf := { l.licenseId | l := licenses[_]; l.isFsfLibre }
+          approved_licenses := osi | fsf
+
+          count(approved_licenses) != 0
+          license != null
+          not license in approved_licenses
+          msg := sprintf("License %s of repo %s/%s is not OSI/FSF approved", [license, owner, repo])
+        }


### PR DESCRIPTION
This rule type checks that the license detected by GitHub is approved by either OSI or FSF. It uses two data sources, one to call GitHub API to get the SPDX identifier of the license, and another one to get the updated list of licenses approved by from SPDX repository.

This rule can be used to implement `OSPS-LE-02`.

P.S.: the name is ugly, please advise. 😅 