### PR TITLE
Add `skip-dirs` configuration for trivy

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -18,6 +18,7 @@ jobs:
           exit-code: 1
           ignore-unfixed: true
           severity: 'CRITICAL'
+          skip-dirs: "./rule-types,./profiles,./data-sources"
         env:
           TRIVY_DB_REPOSITORY: ghcr.io/aquasecurity/trivy-db,public.ecr.aws/aquasecurity/trivy-db
           TRIVY_USERNAME: ${{ github.actor }}


### PR DESCRIPTION
This way it will not check for our test data.

Signed-off-by: Juan Antonio Osorio <ozz@stacklok.com>
