### PR TITLE
Add a check for OSPS-VM-05: contacts and process for vuln reporting

### DIFF
--- a/security-baseline/data-sources/ghapi.yaml
+++ b/security-baseline/data-sources/ghapi.yaml
@@ -1,1 +1,36 @@
-data-sources/ghapi.yaml
+version: v1
+type: data-source
+name: ghapi
+context: {}
+rest:
+  def:
+    license:
+      endpoint: https://api.github.com/repos/{owner}/{repo}/license
+      parse: json
+      input_schema:
+        type: object
+        properties:
+          owner:
+            type: string
+          repo:
+            type: string
+    repo_config:
+      endpoint: https://api.github.com/repos/{owner}/{repo}
+      parse: json
+      input_schema:
+        type: object
+        properties:
+          owner:
+            type: string
+          repo:
+            type: string
+    private_vuln_reporting:
+      endpoint: https://api.github.com/repos/{owner}/{repo}/private-vulnerability-reporting
+      parse: json
+      input_schema:
+        type: object
+        properties:
+          owner:
+            type: string
+          repo:
+            type: string            

--- a/security-baseline/rule-types/github/osps-vm-05.yaml
+++ b/security-baseline/rule-types/github/osps-vm-05.yaml
@@ -1,0 +1,66 @@
+---
+version: v1
+release_phase: alpha
+type: rule-type
+name: osps-vm-05
+display_name: Contacts and process for reporting vulnerabilities is published
+short_failure_message: No contacts or process for reporting vulnerabilities was found
+severity:
+  value: info
+context:
+  provider: github
+description: |
+  This rule ensures that the repository provides a clear process and contact information 
+  for reporting vulnerabilities. 
+  It checks for the presence of a SECURITY.md file containing relevant reporting 
+  details or verifies if GitHub's private vulnerability reporting feature is enabled.
+guidance: |
+  To address this issue:
+  1. Add a `SECURITY.md` file to your repository:
+     - Ensure it includes instructions for reporting vulnerabilities, including contact details and a clear process.
+     - Refer to [GitHub's documentation on SECURITY.md](https://docs.github.com/en/code-security).
+  2. Alternatively, enable GitHub's private vulnerability reporting:
+     - Navigate to the repository's "Settings" - "Security and Analysis."
+     - Enable "Private vulnerability reporting."
+def:
+  in_entity: repository
+  rule_schema: {}
+  ingest:
+    type: git
+  eval:
+    type: rego
+    data_sources:
+      - name: ghapi    
+    rego:
+      type: deny-by-default
+      def: |
+        package minder
+
+        import rego.v1
+
+        default allow := false
+       
+
+        # Allow if SECURITY.md exists and contains "report"
+        allow if {
+            # Search specifically for SECURITY.md
+            files := file.ls_glob("./SECURITY*")
+            count(files) > 0
+
+            # Read the content of the file
+            content := lower(file.read(files[0]))
+            
+            # Check if "report" exists in the content
+            contains(content, "report")
+        }
+
+        # Allow if GitHub vulnerability reporting is enabled
+        allow if {
+          # Query the GitHub API to check vulnerability reporting status
+          out = minder.datasource.ghapi.private_vuln_reporting({
+            "owner": input.properties["github/repo_owner"],
+            "repo": input.properties["github/repo_name"]
+          })
+          # Ensure private vulnerability reporting is enabled
+          out.body.enabled == true
+        }


### PR DESCRIPTION
Add a check for OSPS-VM-05: contacts and process for vuln reporting are published.

No unit tests because they don't support data sources yet, as fas as I know. 

