### PR TITLE
Update security baseline level 1 profile

### DIFF
--- a/security-baseline/profiles/security-baseline-level-1.yaml
+++ b/security-baseline/profiles/security-baseline-level-1.yaml
@@ -30,12 +30,9 @@ repository:
     type: osps-br-03
     def: {}
   # OSPS-BR-09: GitHub hosted releases have this, check for links in release text?
-  # OSPS-BR-10: Not sure how to check this
 
-  # OSPS-DO-13: Support scope and duration is documented
-  - name: osps-do-13
-    type: osps-do-13
-    def: {}
+  # OSPS-DO-03: Ensure user guides for all basic functionality
+  # OSPS-DO-05: Project documentation has a mechanism for reporting defects
 
   # OSPS-GV-02: Projects has public discussion mechanisms
   - name: osps-gv-02
@@ -64,8 +61,6 @@ repository:
   - name: osps-qa-02
     type: osps-qa-02
     def: {}    
-
-  # OSPS-SA-02: Need standardized format?  Also strange that this is lv1, but user guides are lv2
 
   # OSPS-VM-05: Check for SECURITY.md or GitHub private vulnerability reporting
   - name: osps-vm-05


### PR DESCRIPTION
Following the updates to https://baseline.openssf.org/#level-1

- Remove OSPS-BR-10 from level 1
- Remove OSPS-DO-1 from level 1
- Remove OSPS-SA-02 from level 1
- Add placeholder for OSPS-DO-03 in level 1
- Add placeholder for OSPS-DO-05 in level 1