### PR TITLE
Add ruletype for OSPS-BR-09

### DIFF
--- a/security-baseline/profiles/security-baseline-level-1.yaml
+++ b/security-baseline/profiles/security-baseline-level-1.yaml
@@ -29,7 +29,6 @@ repository:
   - name: osps-br-03
     type: osps-br-03
     def: {}
-  # OSPS-BR-09: GitHub hosted releases have this, check for links in release text?
 
   # OSPS-DO-03: Ensure user guides for all basic functionality
   # OSPS-DO-05: Project documentation has a mechanism for reporting defects
@@ -65,4 +64,9 @@ repository:
   # OSPS-VM-05: Check for SECURITY.md or GitHub private vulnerability reporting
   - name: osps-vm-05
     type: osps-vm-05
+    def: {}
+release:
+  # OSPS-BR-09: Released software assets are delivered using HTTPS
+  - name: osps-br-09
+    type: osps-br-09
     def: {}

--- a/security-baseline/rule-types/github/osps-br-09.test.yaml
+++ b/security-baseline/rule-types/github/osps-br-09.test.yaml
@@ -1,0 +1,43 @@
+tests:
+  - name: release assets are https
+    def: {}
+    params: {}
+    entity:
+      type: release
+      entity:
+        properties:
+          github/owner: mindersec
+          github/repo: minder
+          upstream_id: 1
+    expect: pass
+    http:
+      status: 200
+      body_file: all-https.json
+  - name: url is not https
+    def: {}
+    params: {}
+    entity:
+      type: release
+      entity:
+        properties:
+          github/owner: mindersec
+          github/repo: minder
+          upstream_id: 1
+    expect: fail
+    http:
+      status: 200
+      body_file: url-not-https.json
+  - name: download url is not https
+    def: {}
+    params: {}
+    entity:
+      type: release
+      entity:
+        properties:
+          github/owner: mindersec
+          github/repo: minder
+          upstream_id: 1
+    expect: fail
+    http:
+      status: 200
+      body_file: download-url-not-https.json

--- a/security-baseline/rule-types/github/osps-br-09.testdata/all-https.json
+++ b/security-baseline/rule-types/github/osps-br-09.testdata/all-https.json
@@ -1,0 +1,12 @@
+[
+  {
+    "name": "v1.tar.gz",
+    "url": "https://api.github.com/repos/mindersec/minder/releases/assets/1",
+    "browser_download_url": "https://github.com/mindersec/minder/releases/assets/1"
+  },
+  {
+    "name": "v1.zip",
+    "url": "https://api.github.com/repos/mindersec/minder/releases/assets/2",
+    "browser_download_url": "https://github.com/mindersec/minder/releases/assets/2"
+  }
+]

--- a/security-baseline/rule-types/github/osps-br-09.testdata/download-url-not-https.json
+++ b/security-baseline/rule-types/github/osps-br-09.testdata/download-url-not-https.json
@@ -1,0 +1,12 @@
+[
+  {
+    "name": "v1.tar.gz",
+    "url": "https://api.github.com/repos/mindersec/minder/releases/assets/1",
+    "browser_download_url": "https://github.com/mindersec/minder/releases/assets/1"
+  },
+  {
+    "name": "v1.zip",
+    "url": "https://api.github.com/repos/mindersec/minder/releases/assets/2",
+    "browser_download_url": "http://github.com/mindersec/minder/releases/assets/2"
+  }
+]

--- a/security-baseline/rule-types/github/osps-br-09.testdata/url-not-https.json
+++ b/security-baseline/rule-types/github/osps-br-09.testdata/url-not-https.json
@@ -1,0 +1,12 @@
+[
+  {
+    "name": "v1.tar.gz",
+    "url": "http://api.github.com/repos/mindersec/minder/releases/assets/1",
+    "browser_download_url": "https://github.com/mindersec/minder/releases/assets/1"
+  },
+  {
+    "name": "v1.zip",
+    "url": "https://api.github.com/repos/mindersec/minder/releases/assets/2",
+    "browser_download_url": "https://github.com/mindersec/minder/releases/assets/2"
+  }
+]

--- a/security-baseline/rule-types/github/osps-br-09.yaml
+++ b/security-baseline/rule-types/github/osps-br-09.yaml
@@ -1,0 +1,46 @@
+version: v1
+release_phase: alpha
+type: rule-type
+name: osps-br-09
+display_name: Released software assets are delivered using HTTPS
+short_failure_message: Released software assets are not delivered using HTTPS
+severity:
+  value: info
+context:
+  provider: github
+description: |
+  Verifies that released software assets URLs and download URLs are HTTPS.
+guidance: |
+  Ensure the assets that are part of you release have an HTTPS URL and and HTTPS download URL.
+def:
+  in_entity: release
+  rule_schema: { }
+  ingest:
+    type: rest
+    rest:
+      endpoint: "/repos/{{ mapGet .Entity.Properties \"github/owner\" }}/{{ mapGet .Entity.Properties \"github/repo\" }}/releases/{{ mapGet .Entity.Properties \"upstream_id\" }}/assets"
+      parse: json
+  eval:
+    type: rego
+    rego:
+      type: constraints
+      def: |
+        package minder
+
+        import rego.v1
+        
+        # First check the asset URL
+        violations[{"msg": msg}] if {
+          some asset in input.ingested
+
+          not startswith(asset.url, "https://")
+          msg := sprintf("Asset %s URL isn't HTTPS", [asset.name])
+        }
+        
+        # Then check the asset download URL
+        violations[{"msg": msg}] if {
+          some asset in input.ingested
+
+          not startswith(asset.browser_download_url, "https://")
+          msg := sprintf("Asset %s download URL isn't HTTPS", [asset.name])
+        }


### PR DESCRIPTION
Check that the assets that are part of a release have an HTTPS URL and download URL. This should always be the case with GitHub releases.