### PR TITLE
Add OSPS-DO-05 rule

### DIFF
--- a/security-baseline/profiles/security-baseline-level-1.yaml
+++ b/security-baseline/profiles/security-baseline-level-1.yaml
@@ -32,6 +32,9 @@ repository:
 
   # OSPS-DO-03: Ensure user guides for all basic functionality
   # OSPS-DO-05: Project documentation has a mechanism for reporting defects
+  - name: osps-do-05
+    type: osps-do-05
+    def: {}
 
   # OSPS-GV-02: Projects has public discussion mechanisms
   - name: osps-gv-02

--- a/security-baseline/rule-types/github/osps-do-05.test.yaml
+++ b/security-baseline/rule-types/github/osps-do-05.test.yaml
@@ -1,0 +1,51 @@
+tests:
+  - name: "Issues are enabled, discussions are not"
+    def: {}
+    params: {}
+    expect: pass
+    entity:
+      type: repository
+      entity:
+        owner: mindersec
+        name: minder
+    http:
+      status: 200
+      body: |
+        { "has_issues": true, "has_discussions": false }
+  - name: "Discussions are enabled, issues are not"
+    def: {}
+    params: {}
+    expect: pass
+    entity:
+      type: repository
+      entity:
+        owner: mindersec
+        name: discussion
+    http:
+      status: 200
+      body: |
+        { "has_issues": false, "has_discussions": true }
+  - name: "No access enabled"
+    def: {}
+    params: {}
+    expect: fail
+    entity:
+      type: repository
+      entity:
+        owner: mindersec
+        name: retired
+    http:
+      status: 200
+      body: |
+       { "has_issues": false, "has_discussions": false }
+  - name: "No access (404)"
+    def: {}
+    params: {}
+    expect: fail
+    entity:
+      type: repository
+      entity:
+        owner: mindersec
+        name: not-found
+    http:
+      status: 404

--- a/security-baseline/rule-types/github/osps-do-05.yaml
+++ b/security-baseline/rule-types/github/osps-do-05.yaml
@@ -1,0 +1,40 @@
+---
+version: v1
+release_phase: alpha
+type: rule-type
+name: osps-do-05
+display_name: Public feedback mechanism supported
+short_failure_message: No public feedback mechanism found
+severity:
+  value: medium
+context:
+  provider: github
+description: |
+  Ensures that public feedback (via GitHub issues and/or discussions)
+  are available for users of the software, allowing them to report bugs
+  and suggest improvements.
+guidance: |
+  Ensure that issues or discussions are enabled on the repository, and
+  that users can view issues and find reports from other users.
+
+  This rule will not currently detect the usage of an external feedback
+  system (for example, Jira or Trello).
+def:
+  in_entity: repository
+  rule_schema: {}  # No configuration needed
+  ingest:
+    type: rest
+    rest:
+      endpoint: "/repos/{{.Entity.Owner}}/{{.Entity.Name}}"
+      parse: json
+  eval:
+    type: rego
+    rego:
+      type: deny-by-default
+      def: |
+        package minder
+        import rego.v1
+
+        default allow := false
+        allow if input.ingested.has_issues
+        allow if input.ingested.has_discussions


### PR DESCRIPTION
Add an implementation for [OSPS-DO-05](https://baseline.openssf.org/#osps-do-05):

> It is recommended that projects use their VCS default issue tracker. If an extarnal source is used, ensure that the project documentation and contributing guide clearly and visibly explain how to use the reporting system.
>
> It is recommended that project documentation also sets expectations for how defects will be triaged and resolved.

Fixes #288 