### PR TITLE
Shorten the description of BR-01 to fit in <1000 chars

### DIFF
--- a/security-baseline/rule-types/github/osps-br-01.yaml
+++ b/security-baseline/rule-types/github/osps-br-01.yaml
@@ -26,8 +26,7 @@ description: |
   detects whether a workflow's inline script may execute untrusted
   input from attackers. Attackers can add their own content to
   certain github context variables that are considered untrusted,
-  for example, github.event.issue.title. These values should not flow
-  directly into executable code.
+  for example, github.event.issue.title.
 
 guidance: |
   Avoid using pull_request_target and workflow_run workflow triggers with
@@ -138,5 +137,3 @@ def:
           matcher := concat("", ["*", match, "*"])
           glob.match(matcher, null, exp)
         }
-
-


### PR DESCRIPTION
```
$ minder ruletype apply -f security-baseline/rule-types/github/osps-br-01.yaml
No config file present, using default values.
Message: error applying rule type from security-baseline/rule-types/github/osps-br-01.yaml
Details: error creating rule type from security-baseline/rule-types/github/osps-br-01.yaml: rpc error: code = InvalidArgument desc = Validation failed:
- Field 'rule_type.description': value length must be at most 1000 characters
```
