### PR TITLE
Migrate rule policies to Rego v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,22 @@ Apart from that, you can also check the reference rules and profiles in this rep
   into use, you'll need to instantiate it in a Minder instance. For example, to instantiate the
   reference data source for using OSV as a data source, use the following command - `minder datasource create -f data-sources osv.yaml`.
 
+### Migrating Rego rule definitions to v1
+
+Rule type YAML files can embed Rego policies under `def.eval.rego.def`. To migrate those policies from Rego v0 syntax
+to Rego v1 syntax across this repository, install OPA v1 or newer and run:
+
+```sh
+task migrate-rego-v1
+```
+
+The task runs `opa fmt --v0-v1` against each embedded Rego `def: |` block and writes the formatted source back into the
+YAML file. You can also run the script directly against a specific path:
+
+```sh
+python3 scripts/migrate-rego-v1.py rule-types/github/secret_scanning.yaml
+```
+
 ## How to contribute?
 
 We welcome contributions!

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -2,6 +2,16 @@
 version: '3'
 
 tasks:
+  migrate-rego-v1:
+    desc: Migrate embedded Rego rule definitions to Rego v1 syntax
+    summary: |
+      Updates Rego policies embedded in YAML rule type `def: |` blocks by
+      running OPA's built-in v0-to-v1 formatter.
+
+      Requires OPA v1 or newer to be available on PATH.
+    cmds:
+      - python3 scripts/migrate-rego-v1.py .
+
   test:
     desc: Run rule type tests
     summary: |

--- a/autofill-insights/rule-types/insights_exists.yaml
+++ b/autofill-insights/rule-types/insights_exists.yaml
@@ -29,9 +29,10 @@ def:
       type: deny-by-default
       def: |
         package minder
+
         import rego.v1
 
-        insights_files = [
+        insights_files := [
           "SECURITY-INSIGHTS.yaml",
           "SECURITY-INSIGHTS.yml",
           "security-insights.yaml",
@@ -41,20 +42,31 @@ def:
           ".gitlab/security-insights.yaml",
           ".gitlab/security-insights.yml",
           ".project/security-insights.yaml",
-          ".project/security-insights.yml"
+          ".project/security-insights.yml",
         ]
 
         default allow := false
-        allow := true if count([ e | some e in insights_files; file.exists(e) ]) > 0
+
+        allow if count([e | some e in insights_files; file.exists(e)]) > 0
+
         # message := sprintf("Could not find Security Insights in %v", [insights_files]) if not allow
 
         today := sprintf("%04d-%02d-%02d", time.date(time.now_ns()))
-        base_url := sprintf("https://github.com/%s/%s",
-          [input.properties["github/repo_owner"], input.properties["github/repo_name"]])
-        blob_stub := sprintf("%s/blob/%s",
-          [base_url, input.properties["github/default_branch"]])
-        raw_stub := sprintf("https://raw.githubusercontent.com/%s/%s/%s",
-          [input.properties["github/repo_owner"], input.properties["github/repo_name"], input.properties["github/default_branch"]])
+        base_url := sprintf(
+          "https://github.com/%s/%s",
+          [input.properties["github/repo_owner"], input.properties["github/repo_name"]],
+        )
+
+        blob_stub := sprintf(
+          "%s/blob/%s",
+          [base_url, input.properties["github/default_branch"]],
+        )
+
+        raw_stub := sprintf(
+          "https://raw.githubusercontent.com/%s/%s/%s",
+          [input.properties["github/repo_owner"], input.properties["github/repo_name"], input.properties["github/default_branch"]],
+        )
+
         content.header["schema-version"] := "2.2.0"
         content.header["last-updated"] := today
         content.header["last-reviewed"] := today
@@ -64,51 +76,58 @@ def:
 
         content.repository.url := base_url
         content.repository.status := "active"
+
         # Required field for validation
         content.repository.security.assessments := {}
-        
+
         # File-based content discovery
-        content.repository.documentation["contributing-guide"] := sprintf(
-          "%s/CONTRIBUTING.md", [blob_stub]) if file.exists("CONTRIBUTING.md")
-        content.repository.documentation["security-policy"] := sprintf(
-          "%s/SECURITY.md", [blob_stub]) if file.exists("SECURITY.md")
-        content.project["vulnerability-reporting"].policy := sprintf(
-          "%s/SECURITY.md", [blob_stub]) if file.exists("SECURITY.md")
+        content.repository.documentation["contributing-guide"] := sprintf("%s/CONTRIBUTING.md", [blob_stub]) if {
+          file.exists("CONTRIBUTING.md")
+        }
+
+        content.repository.documentation["security-policy"] := sprintf("%s/SECURITY.md", [blob_stub]) if {
+          file.exists("SECURITY.md")
+        }
+
+        content.project["vulnerability-reporting"].policy := sprintf("%s/SECURITY.md", [blob_stub]) if {
+          file.exists("SECURITY.md")
+        }
 
         # API-based content discovery
         repo_config := minder.datasource.insightsghapi.repo_config({
           "owner": input.properties["github/repo_owner"],
-          "repo": input.properties["github/repo_name"]
+          "repo": input.properties["github/repo_name"],
         }).body
 
-        content.project.repositories := [
-          {
-            "name": input.properties["github/repo_name"],
-            "url": base_url,
-            "comment": repo_config.description,
-          }
-        ]
+        content.project.repositories := [{
+          "name": input.properties["github/repo_name"],
+          "url": base_url,
+          "comment": repo_config.description,
+        }]
+
         content.project.homepage := repo_config.homepage if repo_config.homepage != null
 
         content.repository["accepts-change-request"] if {
           repo_config.has_pull_requests
           repo_config.pull_request_creation_policy == "all"
         }
+
         content.repository["accepts-automated-change-request"] := content.repository["accepts-change-request"]
-        
+
         content.repository.license.url := repo_config.license.url
         content.repository.license.expression := repo_config.license.spdx_id
 
         vuln_reporting := minder.datasource.insightsghapi.private_vuln_reporting({
           "owner": input.properties["github/repo_owner"],
-          "repo": input.properties["github/repo_name"]
+          "repo": input.properties["github/repo_name"],
         }).body
+
         content.project["vulnerability-reporting"]["reports-accepted"] := vuln_reporting.enabled
         content.project["vulnerability-reporting"]["bug-bounty-available"] := false
 
         members := minder.datasource.insightsghapi.members({
           "owner": input.properties["github/repo_owner"],
-          "repo": input.properties["github/repo_name"]
+          "repo": input.properties["github/repo_name"],
         }).body
 
         administrators contains {"name": user.login, "primary": false} if {
@@ -120,8 +139,7 @@ def:
         content.repository["core-team"] := administrators
 
         # Encode for remediation output
-        output.content = yaml.marshal(content)
-
+        output.content := yaml.marshal(content)
   remediate:
     type: pull_request
     pull_request:

--- a/autofill-insights/rule-types/insights_up_to_date.yaml
+++ b/autofill-insights/rule-types/insights_up_to_date.yaml
@@ -30,6 +30,7 @@ def:
       type: constraints
       def: |
         package minder
+
         import rego.v1
 
         default output := {"patches": "{}"}
@@ -47,12 +48,13 @@ def:
           "security-insights.yaml",
         ]
 
-        si_files := [ e | some e in insights_files; file.exists(e) ]
+        si_files := [e | some e in insights_files; file.exists(e)]
 
         si_contents := file.read(si_files[0]) if count(si_files) > 0
         si_contents := "" if count(si_files) == 0
 
         default current := {}
+
         current := yaml.unmarshal(si_contents) if yaml.is_valid(si_contents)
         violations contains {"msg": "Security Insights file is missing or malformed"} if {
           current == {}
@@ -62,57 +64,77 @@ def:
         # These _override_ values specified in the file, if defined.
         detected.header["schema-version"] := "2.2.0"
         detected.header["last-updated"] := object.get(current, ["header", "last-updated"], sprintf("%04d-%02d-%02d", time.date(time.now_ns())))
-        detected.header["url"] := sprintf("https://raw.githubusercontent.com/%s/%s/%s/%s",
-          [input.properties["github/repo_owner"], input.properties["github/repo_name"], input.properties["github/default_branch"], si_files[0]])
+        detected.header.url := sprintf(
+          "https://raw.githubusercontent.com/%s/%s/%s/%s",
+          [input.properties["github/repo_owner"], input.properties["github/repo_name"], input.properties["github/default_branch"], si_files[0]],
+        )
+
         detected.repository.status := "active"
-        detected.repository["security"] := {
-              "assessments": {}
-            }
-        base_url := sprintf("https://github.com/%s/%s",
-          [input.properties["github/repo_owner"], input.properties["github/repo_name"]])
-        blob_stub := sprintf("%s/blob/%s",
-          [base_url, input.properties["github/default_branch"]])
+        detected.repository.security := {"assessments": {}}
+
+        base_url := sprintf(
+          "https://github.com/%s/%s",
+          [input.properties["github/repo_owner"], input.properties["github/repo_name"]],
+        )
+
+        blob_stub := sprintf(
+          "%s/blob/%s",
+          [base_url, input.properties["github/default_branch"]],
+        )
 
         reviewed_str := object.get(current, ["header", "last-reviewed"], "1970-01-01")
-        default review_age := 100000000000000000  # Needs to be a constant, this is about 1150 days
+
+        default review_age := 100000000000000000 # Needs to be a constant, this is about 1150 days
+
         review_age := time.now_ns() - time.parse_ns("2006-01-02", reviewed_str)
-        needs_review if review_age > time.parse_duration_ns("8760h")  # 1 year
+        needs_review if review_age > time.parse_duration_ns("8760h") # 1 year
         violations contains {"msg": "Security Insights file has not been reviewed"} if {
           needs_review
         }
+
         detected.header["last-reviewed"] := sprintf("%04d-%02d-%02d", time.date(time.now_ns())) if {
           needs_review
         }
+
         detected.header["last-reviewed"] := current.header["last-reviewed"] if {
           not needs_review
         }
 
         # File-based content discovery
-        detected.repository.documentation["contributing-guide"] := sprintf(
-          "%s/CONTRIBUTING.md", [blob_stub]) if file.exists("CONTRIBUTING.md")
-        detected.repository.documentation["security-policy"] := sprintf(
-          "%s/SECURITY.md", [blob_stub]) if file.exists("SECURITY.md")
-        detected.project["vulnerability-reporting"].policy := sprintf(
-          "%s/SECURITY.md", [blob_stub]) if file.exists("SECURITY.md")
+        detected.repository.documentation["contributing-guide"] := sprintf("%s/CONTRIBUTING.md", [blob_stub]) if {
+          file.exists("CONTRIBUTING.md")
+        }
+
+        detected.repository.documentation["security-policy"] := sprintf("%s/SECURITY.md", [blob_stub]) if {
+          file.exists("SECURITY.md")
+        }
+
+        detected.project["vulnerability-reporting"].policy := sprintf("%s/SECURITY.md", [blob_stub]) if {
+          file.exists("SECURITY.md")
+        }
 
         # API-based content discovery
         repo_config := minder.datasource.insightsghapi.repo_config({
           "owner": input.properties["github/repo_owner"],
-          "repo": input.properties["github/repo_name"]
+          "repo": input.properties["github/repo_name"],
         }).body
 
-        detected.project["name"] := object.get(current, ["project", "name"], repo_config.name)
+        detected.project.name := object.get(current, ["project", "name"], repo_config.name)
         detected.repository.url := base_url
+
         detected.repository["accepts-change-request"] if {
           repo_config.has_pull_requests
           repo_config.pull_request_creation_policy == "all"
         }
+
         detected.repository["accepts-automated-change-request"] := detected.repository["accepts-change-request"]
-        detected.repository["license"] := {
-              "url": repo_config.license.url,
-              "expression": repo_config.license.spdx_id
-            }
+        detected.repository.license := {
+          "url": repo_config.license.url,
+          "expression": repo_config.license.spdx_id,
+        }
+
         detected.project.homepage := repo_config.homepage if repo_config.homepage != null
+
         # TODO: project.documentation, particularly code-of-conduct
 
         # include existing projects
@@ -125,26 +147,28 @@ def:
             repo.url != base_url
           }
           e := {
-            "url" : base_url,
-            "comment" : repo_config.description,
-            "name" : input.properties["github/repo_name"],
+            "url": base_url,
+            "comment": repo_config.description,
+            "name": input.properties["github/repo_name"],
           }
         }
 
         vuln_reporting := minder.datasource.insightsghapi.private_vuln_reporting({
           "owner": input.properties["github/repo_owner"],
-          "repo": input.properties["github/repo_name"]
+          "repo": input.properties["github/repo_name"],
         }).body
-        reports_enabled if { object.get(current, ["project", "vulnerability-reporting", "reports-accepted"], false) == true }
-        reports_enabled if { vuln_reporting.enabled }
+
+        reports_enabled if object.get(current, ["project", "vulnerability-reporting", "reports-accepted"], false) == true
+        reports_enabled if vuln_reporting.enabled
 
         detected.project["vulnerability-reporting"]["reports-accepted"] := reports_enabled
         detected.project["vulnerability-reporting"]["bug-bounty-available"] := object.get(current, ["project", "vulnerability-reporting", "bug-bounty-available"], false)
 
         members := minder.datasource.insightsghapi.members({
           "owner": input.properties["github/repo_owner"],
-          "repo": input.properties["github/repo_name"]
+          "repo": input.properties["github/repo_name"],
         }).body
+
         administrators contains {"name": user.login, "primary": false} if {
           some user in members
           user.permissions.admin == true
@@ -153,22 +177,25 @@ def:
         detected.project.administrators contains e if {
           e := object.get(current, ["project", "administrators"], [])[_]
         }
+
         detected.project.administrators contains {"name": user.name, "primary": false} if {
           some user in administrators
           every admin in object.get(current, ["project", "administrators"], []) {
             user.name != admin.name
           }
         }
+
         detected.repository["core-team"] contains e if {
           e := object.get(current, ["repository", "core-team"], [])[_]
         }
+
         detected.repository["core-team"] contains {"name": user.name, "primary": false} if {
           some user in administrators
           every admin in object.get(current, ["repository", "core-team"], []) {
             user.name != admin.name
           }
         }
-        
+
         # TODO: governance, review-policy, dependency-management-policy, etc.
 
         # Generate override object as JSON for merging with YQ if needed
@@ -178,7 +205,6 @@ def:
         violations contains {"msg": "Security Insights file is not up to date with repository information"} if {
           json.marshal(current) != json.marshal(merged)
         }
-
   remediate:
     type: pull_request
     pull_request:

--- a/docs/rule-type-quick-reference.md
+++ b/docs/rule-type-quick-reference.md
@@ -86,7 +86,7 @@ eval:
     def: |
       package minder
 
-      import future.keywords.if
+      import rego.v1
 
       default allow := false
       default skip := false
@@ -111,7 +111,7 @@ eval:
     def: |
       package minder
 
-      violations[{"msg": msg}] {
+      violations contains {"msg": msg} if {
         # Logic to find violations
         msg := "Violation description"
       }
@@ -294,7 +294,7 @@ allow if {
 ### Check All Workflow Files
 
 ```rego
-violations[{"msg": msg}] {
+violations contains {"msg": msg} if {
   workflows := file.ls("./.github/workflows")
   some w
   workflowstr := file.read(workflows[w])
@@ -555,7 +555,7 @@ def:
       def: |
         package minder
 
-        import future.keywords.if
+        import rego.v1
 
         default allow := false
 

--- a/docs/writing-rule-types.md
+++ b/docs/writing-rule-types.md
@@ -271,7 +271,7 @@ def:
       def: |
         package minder
 
-        import future.keywords.if
+        import rego.v1
 
         default allow := false
         default skip := false
@@ -309,7 +309,7 @@ def:
       def: |
         package minder
 
-        violations[{"msg": msg}] {
+        violations contains {"msg": msg} if {
           # Check condition
           workflows := file.ls("./.github/workflows")
           some w
@@ -517,7 +517,7 @@ def:
       def: |
         package minder
 
-        import future.keywords.if
+        import rego.v1
 
         default allow := false
         default message := "Repository issues are not enabled"
@@ -579,7 +579,7 @@ def:
       def: |
         package minder
 
-        import future.keywords.if
+        import rego.v1
 
         default allow := false
         fileStr := file.read(input.profile.license_filename)
@@ -704,7 +704,7 @@ def:
       def: |
         package minder
 
-        import future.keywords.if
+        import rego.v1
 
         default allow := false
         default message := "Branch protection is not enabled"
@@ -911,7 +911,7 @@ skip if {
 Report multiple issues in one evaluation:
 
 ```rego
-violations[{"msg": msg}] {
+violations contains {"msg": msg} if {
   # Iterate over items
   some i
   item := input.ingested[i]
@@ -929,9 +929,7 @@ violations[{"msg": msg}] {
 Use Rego's full power for complex checks:
 
 ```rego
-import future.keywords.every
-import future.keywords.if
-import future.keywords.in
+import rego.v1
 
 allow if {
   # All items must pass
@@ -1003,7 +1001,7 @@ allow if {
 ### Pattern 4: Workflow File Analysis
 
 ```rego
-violations[{"msg": msg}] {
+violations contains {"msg": msg} if {
   workflows := file.ls("./.github/workflows")
   some w
   workflowstr := file.read(workflows[w])

--- a/rule-types/common/dockerfile_no_latest_tag.yaml
+++ b/rule-types/common/dockerfile_no_latest_tag.yaml
@@ -42,7 +42,9 @@ def:
       def: |
         package minder
 
-        violations[{"msg": msg}] {
+        import rego.v1
+
+        violations contains {"msg": msg} if {
           # Read Dockerfile
           dockerfile := file.read("Dockerfile")
 

--- a/rule-types/common/enforce_file.yaml
+++ b/rule-types/common/enforce_file.yaml
@@ -53,34 +53,36 @@ def:
       def: |
         package minder
 
-        import future.keywords.if
+        import rego.v1
 
         default allow := false
+
         default skip := false
+
         fileStr := trim_space(file.read(input.profile.file))
 
         # Skip if apply_if_file is specified and the file doesn't exist
         skip if {
-            input.profile.apply_if_file != ""
-            not file.exists(input.profile.apply_if_file)
+          input.profile.apply_if_file != ""
+          not file.exists(input.profile.apply_if_file)
         }
 
         allow if {
-            # Read the file and check if it contains the content
-            fileStr == trim_space(input.profile.content)
+          # Read the file and check if it contains the content
+          fileStr == trim_space(input.profile.content)
         } else if {
-            # Check if the file exists and the content is left blank
-            file.exists(input.profile.file)
-            input.profile.content == ""
+          # Check if the file exists and the content is left blank
+          file.exists(input.profile.file)
+          input.profile.content == ""
         }
-        
+
         message := sprintf("Skipping rule because file %v does not exist", [input.profile.apply_if_file]) if {
-            input.profile.apply_if_file != ""
-            not file.exists(input.profile.apply_if_file)
+          input.profile.apply_if_file != ""
+          not file.exists(input.profile.apply_if_file)
         } else := sprintf("File %v does not exist", [input.profile.file]) if {
-            not file.exists(input.profile.file)
+          not file.exists(input.profile.file)
         } else := sprintf("File %v does not match the expected content %v", [input.profile.file, input.profile.content]) if {
-            fileStr != trim_space(input.profile.content)
+          fileStr != trim_space(input.profile.content)
         }
   remediate:
     type: pull_request

--- a/rule-types/common/license.yaml
+++ b/rule-types/common/license.yaml
@@ -56,26 +56,26 @@ def:
       def: |
         package minder
 
-        import future.keywords.if
+        import rego.v1
 
         default allow := false
+
         fileStr := file.read(input.profile.license_filename)
 
         allow if {
-            # Read the license file and check if it contains the license type
-            contains(fileStr, input.profile.license_type)
+          # Read the license file and check if it contains the license type
+          contains(fileStr, input.profile.license_type)
         } else if {
-            # Check if the file exists and the license type is left blank
-            file.exists(input.profile.license_filename)
-            input.profile.license_type == ""
-        }
-        
-        message := sprintf("License file %v does not exist", [input.profile.license_filename]) if {
-            not file.exists(input.profile.license_filename)
-        } else := sprintf("License file %v does not match the expected license type %v", [input.profile.license_filename, input.profile.license_type]) if {
-            not contains(fileStr, input.profile.license_type)
+          # Check if the file exists and the license type is left blank
+          file.exists(input.profile.license_filename)
+          input.profile.license_type == ""
         }
 
+        message := sprintf("License file %v does not exist", [input.profile.license_filename]) if {
+          not file.exists(input.profile.license_filename)
+        } else := sprintf("License file %v does not match the expected license type %v", [input.profile.license_filename, input.profile.license_type]) if {
+          not contains(fileStr, input.profile.license_type)
+        }
   # Defines the configuration for alerting on the rule
   alert:
     type: security_advisory

--- a/rule-types/common/osv_vulnerabilities.yaml
+++ b/rule-types/common/osv_vulnerabilities.yaml
@@ -33,63 +33,60 @@ def:
       type: constraints
       def: |
         package minder
-        
+
         import rego.v1
-        
-        default skip = false
-        
+
+        default skip := false
+
         violations[{"msg": msg}] if {
           node := input.ingested.node_list.nodes[_]
-          
+
           name := node.name
           version := node.version
           ecosystem := get_ecosystem(node.properties)
-          
-          reqparams := {
-              "query": {
-                "version": version,
-                "package": {
-                  "name": name,
-                  "ecosystem": ecosystem
-                }
-              }
-            }
-          
+
+          reqparams := {"query": {
+            "version": version,
+            "package": {
+              "name": name,
+              "ecosystem": ecosystem,
+            },
+          }}
+
           out := minder.datasource.osv.query(reqparams)
           vulns := out.body.vulns
-          
+
           count(vulns) > 0
-          
+
           vulnid := vulns[_].id
-          
+
           msg := sprintf("Package %v version %v has a vulnerability %v", [name, version, vulnid])
         }
-        
+
         get_ecosystem(properties) := eco if {
           count(properties) >= 1
           prop := properties[_]
-          
+
           prop.name == "sourceFile"
           eco := get_ecosystem_from_file(prop.data)
         }
-        
-        get_ecosystem_from_file(file) = "PyPI" if {
+
+        get_ecosystem_from_file(file) := "PyPI" if {
           file == "requirements.txt"
         }
-        
-        get_ecosystem_from_file(file) = "npm" if {
+
+        get_ecosystem_from_file(file) := "npm" if {
           file == "package.json"
         }
-        
-        get_ecosystem_from_file(file) = "RubyGems" if {
+
+        get_ecosystem_from_file(file) := "RubyGems" if {
           file == "Gemfile"
         }
-        
-        get_ecosystem_from_file(file) = "Go" if {
+
+        get_ecosystem_from_file(file) := "Go" if {
           file == "go.mod"
         }
-        
-        get_ecosystem_from_file(file) = "crates.io" if {
+
+        get_ecosystem_from_file(file) := "crates.io" if {
           file == "Cargo.toml"
         }
-

--- a/rule-types/common/python_lock_file_exists.yaml
+++ b/rule-types/common/python_lock_file_exists.yaml
@@ -46,53 +46,54 @@ def:
         import rego.v1
 
         default allow := false
-        
+
         allow if lockfilecheck
-        
+
         allow if reqtxtcheck
-        
+
         lock_files := ["Pipfile.lock", "poetry.lock", "pdm.lock"]
-        
+
         lockfilecheck if {
-            # If we'll skip this repo let's not even try to evaluate the rest of the rule
-            not skip
-        
-            # Check if any of the lock files exist in the repository
-            some f in lock_files
-            file.exists(f)
+          # If we'll skip this repo let's not even try to evaluate the rest of the rule
+          not skip
+
+          # Check if any of the lock files exist in the repository
+          some f in lock_files
+          file.exists(f)
         }
-        
+
         reqtxtcheck if {
-            # If we'll skip this repo let's not even try to evaluate the rest of the rule
-            not skip
-        
-            # If the project is using a requirements.txt, we need to ensure that
-            # dependencies are pinned to specific versions and not ranges.
-            file.exists("requirements.txt")
-        
-            # Check if the requirements.txt file contains any version ranges
-            rqtxt := file.read("requirements.txt")
-            ranges := regex.find_all_string_submatch_n(`.*[=><]+.*`, rqtxt, -1)
-        
-            print("Ranges: ", ranges)
-            # Check that versions are pinned in the requirements.txt file
-            # TODO: This is a simple check that looks for the presence of '=='
-            #             We should consider hashes in the future
-            matches := regex.find_all_string_submatch_n(`.*==.*`, rqtxt, -1)
-        
-            # Check that all dependencies are pinned to specific versions
-            count(matches) == count(ranges)
+          # If we'll skip this repo let's not even try to evaluate the rest of the rule
+          not skip
+
+          # If the project is using a requirements.txt, we need to ensure that
+          # dependencies are pinned to specific versions and not ranges.
+          file.exists("requirements.txt")
+
+          # Check if the requirements.txt file contains any version ranges
+          rqtxt := file.read("requirements.txt")
+          ranges := regex.find_all_string_submatch_n(`.*[=><]+.*`, rqtxt, -1)
+
+          print("Ranges: ", ranges)
+
+          # Check that versions are pinned in the requirements.txt file
+          # TODO: This is a simple check that looks for the presence of '=='
+          #             We should consider hashes in the future
+          matches := regex.find_all_string_submatch_n(`.*==.*`, rqtxt, -1)
+
+          # Check that all dependencies are pinned to specific versions
+          count(matches) == count(ranges)
         }
-        
+
         # If there's none of these files, this most likely is not a Python project
         skip if {
-            not file.exists("pyproject.toml")
-            not file.exists("requirements.txt")
-            not file.exists("Pipfile")
+          not file.exists("pyproject.toml")
+          not file.exists("requirements.txt")
+          not file.exists("Pipfile")
         }
-        
+
         message := "There is no lock file in the repository" if {
-            not lockfilecheck
+          not lockfilecheck
         } else := "requirements.txt file does not pin dependencies to specific versions" if {
-            not reqtxtcheck
+          not reqtxtcheck
         }

--- a/rule-types/common/require_pre_commit_to_be_configured.yaml
+++ b/rule-types/common/require_pre_commit_to_be_configured.yaml
@@ -27,22 +27,22 @@ def:
       type: deny-by-default
       def: |
         package minder
-        import future.keywords.if
-        import future.keywords.every
+
+        import rego.v1
 
         default message := "pre-commit configuration file missing"
+
         default allow := false
 
-        
         # pre-commit hook
         precommit := file.read(".pre-commit-config.yaml")
-        
+
         parsed_data := parse_yaml(precommit)
 
         allow if {
           some repo_id, hook_id
           repo_data := parsed_data.repos[repo_id]
-          hooks = repo_data["hooks"]
+          hooks = repo_data.hooks
 
           hooks[hook_id]
         }

--- a/rule-types/common/sonatype_oss_index_vulnerabilities.yaml
+++ b/rule-types/common/sonatype_oss_index_vulnerabilities.yaml
@@ -34,30 +34,24 @@ def:
       type: constraints
       def: |
         package minder
-        
+
         import rego.v1
-        
-        default skip = false
-        
+
+        default skip := false
+
         violations[{"msg": msg}] if {
           node := input.ingested.node_list.nodes[_]
-          
+
           purl := node.identifiers["1"]
-          
-          reqparams := {
-              "request": {
-                "coordinates": [
-                    purl
-                ]
-              }
-            }
-          
+
+          reqparams := {"request": {"coordinates": [purl]}}
+
           out := minder.datasource.sonatype_oss_index.query(reqparams)
           vulns := out.body[0].vulnerabilities
-          
+
           count(vulns) > 0
-          
+
           vulnid := vulns[_].id
-          
+
           msg := sprintf("Package '%v' has a vulnerability %v", [purl, vulnid])
         }

--- a/rule-types/github/actions_check_default_permissions.yaml
+++ b/rule-types/github/actions_check_default_permissions.yaml
@@ -39,23 +39,22 @@ def:
       type: deny-by-default
       def: |
         package minder
-        
+
         import rego.v1
 
         default allow := false
-        
+
         # List all workflows
         workflows := file.ls("./.github/workflows")
-        
+
         # Read all workflows
-        
+
         allow if {
           every filename in workflows {
-            
             workflowstr := file.read(filename)
-          
+
             workflow := yaml.unmarshal(workflowstr)
-          
+
             permissions_ok(workflow)
           }
         }
@@ -69,15 +68,15 @@ def:
             count(job.permissions) >= 0
           }
         }
-        
+
         # Get the list of workflows that do not have permissions and create the error message
-        missing_permissions_workflows = [workflow_name | 
-          filename := workflows[_]  # Iterate over each workflow filename
+        missing_permissions_workflows := [workflow_name |
+          filename := workflows[_] # Iterate over each workflow filename
           workflowstr := file.read(filename)
-          workflow := yaml.unmarshal(workflowstr) 
+          workflow := yaml.unmarshal(workflowstr)
 
           not permissions_ok(workflow)
-          workflow_name = workflow.name 
+          workflow_name = workflow.name
         ]
 
         # Construct the final message

--- a/rule-types/github/actions_check_pinned_tags.yaml
+++ b/rule-types/github/actions_check_pinned_tags.yaml
@@ -59,12 +59,14 @@ def:
       def: |
         package minder
 
-        is_excluded(action, excludes) {
+        import rego.v1
+
+        is_excluded(action, excludes) if {
           some i
           action == excludes[i]
         }
 
-        violations[{"msg": msg}] {
+        violations contains {"msg": msg} if {
           # List all workflows
           workflows := file.ls("./.github/workflows")
 

--- a/rule-types/github/artifact_attestation_slsa.yaml
+++ b/rule-types/github/artifact_attestation_slsa.yaml
@@ -90,12 +90,15 @@ def:
         import rego.v1
 
         default allow := false
+
         default skip := false
+
         default message := "Cannot verify SLSA provenance"
-        
+
         default workflow_ref := "refs/heads/main"
+
         workflow_ref := input.profile.workflow_ref
-        
+
         artifacts_github_provenance := {artifact |
           some artifact in input.ingested
           artifact.Verification.attestation.predicate_type == "https://slsa.dev/provenance/v1"
@@ -104,7 +107,7 @@ def:
 
         allow if {
           count(artifacts_github_provenance) > 0
-        
+
           every artifact in artifacts_github_provenance {
             # we use not == false here because that handles the case where the field is not present
             # the fields are also not exposed as parameters, we might want to change them while we reword the

--- a/rule-types/github/artifact_signature.yaml
+++ b/rule-types/github/artifact_signature.yaml
@@ -94,10 +94,9 @@ def:
       def: |
         package minder
 
-        import future.keywords.every
-        import future.keywords.if
+        import rego.v1
 
-        violations[{"msg": msg}] {
+        violations contains {"msg": msg} if {
           # iterate over the artifacts. We want all artifacts to be checked individually
           artifactVersion := input.ingested[_]
 

--- a/rule-types/github/branch_protection_enabled.yaml
+++ b/rule-types/github/branch_protection_enabled.yaml
@@ -54,13 +54,13 @@ def:
       type: deny-by-default
       def: |
         package minder
-        
-        import future.keywords.every
-        import future.keywords.if
-        
+
+        import rego.v1
+
         default allow := false
+
         default message := "No branch protection rule is set"
-        
+
         allow if {
           input.ingested.url != ""
         }

--- a/rule-types/github/branch_protection_require_pull_requests.yaml
+++ b/rule-types/github/branch_protection_require_pull_requests.yaml
@@ -64,13 +64,13 @@ def:
       type: deny-by-default
       def: |
         package minder
-        
-        import future.keywords.every
-        import future.keywords.if
-        
+
+        import rego.v1
+
         default allow := false
+
         default message := "Pull requests are not required"
-        
+
         allow if {
           input.ingested.required_pull_request_reviews.url != ""
         }

--- a/rule-types/github/branch_protection_require_status_checks.yaml
+++ b/rule-types/github/branch_protection_require_status_checks.yaml
@@ -55,9 +55,10 @@ def:
       def: |
         package minder
 
-        import future.keywords.if
+        import rego.v1
 
         default allow := false
+
         default message := "Status checks are not required before merging"
 
         allow if {

--- a/rule-types/github/codeql_enabled.yaml
+++ b/rule-types/github/codeql_enabled.yaml
@@ -58,23 +58,26 @@ def:
       def: |
         package minder
 
+        import rego.v1
+
         default allow := false
+
         default message := "CodeQL is not enabled"
 
-        allow {
-            # List all workflows
-            workflows := file.ls("./.github/workflows")
+        allow if {
+          # List all workflows
+          workflows := file.ls("./.github/workflows")
 
-            # Read all workflows
-            some w
-            workflowstr := file.read(workflows[w])
+          # Read all workflows
+          some w
+          workflowstr := file.read(workflows[w])
 
-            workflow := yaml.unmarshal(workflowstr)
+          workflow := yaml.unmarshal(workflowstr)
 
-            # Ensure a workflow contains the codel-ql action
-            some i
-            steps := workflow.jobs.analyze.steps[i]
-            startswith(steps.uses, "github/codeql-action/analyze@")
+          # Ensure a workflow contains the codel-ql action
+          some i
+          steps := workflow.jobs.analyze.steps[i]
+          startswith(steps.uses, "github/codeql-action/analyze@")
         }
   remediate:
     type: pull_request

--- a/rule-types/github/dependabot_configured.yaml
+++ b/rule-types/github/dependabot_configured.yaml
@@ -64,26 +64,29 @@ def:
       def: |
         package minder
 
+        import rego.v1
+
         default allow := false
+
         default message := "Dependabot is not configured"
 
         # Set allow if we don't need to skip and the rule evaluation passes
-        allow {
-            # Read the dependabot configuration
-            fileStr := file.read("./.github/dependabot.yml")
+        allow if {
+          # Read the dependabot configuration
+          fileStr := file.read("./.github/dependabot.yml")
 
-            # Parse the YAML content
-            config := yaml.unmarshal(fileStr)
+          # Parse the YAML content
+          config := yaml.unmarshal(fileStr)
 
-            # Ensure a configuration contains the package ecosystem daily update schedule
-            update := config.updates[_]
-            update["package-ecosystem"] == input.profile.package_ecosystem
+          # Ensure a configuration contains the package ecosystem daily update schedule
+          update := config.updates[_]
+          update["package-ecosystem"] == input.profile.package_ecosystem
         }
 
         # We skip if the apply_if_file is specified and the file does not exist
-        skip {
-            input.profile.apply_if_file != ""
-            not file.exists(input.profile.apply_if_file)
+        skip if {
+          input.profile.apply_if_file != ""
+          not file.exists(input.profile.apply_if_file)
         }
   remediate:
     type: pull_request

--- a/rule-types/github/golangci-lint_github_action.yaml
+++ b/rule-types/github/golangci-lint_github_action.yaml
@@ -30,13 +30,15 @@ def:
       type: deny-by-default
       def: |
         package minder
-        
+
         import rego.v1
 
         actions := github_workflow.ls_actions("./.github/workflows")
 
         default message := "golangci-lint GitHub action is not configured"
+
         default allow := false
+
         allow if {
           # check that there is a golanci-lint action
           "golangci/golangci-lint-action" in actions

--- a/rule-types/github/grype_github_action_scan_container_image.yaml
+++ b/rule-types/github/grype_github_action_scan_container_image.yaml
@@ -41,28 +41,31 @@ def:
       def: |
         package minder
 
+        import rego.v1
+
         default allow := false
+
         default message := "Grype GitHub Action is not enabled for container image scanning."
 
-        allow {
-            # List all workflows
-            workflows := file.ls("./.github/workflows")
+        allow if {
+          # List all workflows
+          workflows := file.ls("./.github/workflows")
 
-            # Read all workflows
-            some w
-            workflowstr := file.read(workflows[w])
+          # Read all workflows
+          some w
+          workflowstr := file.read(workflows[w])
 
-            workflow := yaml.unmarshal(workflowstr)
+          workflow := yaml.unmarshal(workflowstr)
 
-            # Iterate jobs
-            job := workflow.jobs[_]
+          # Iterate jobs
+          job := workflow.jobs[_]
 
-            # Iterate steps
-            step := job.steps[_]
+          # Iterate steps
+          step := job.steps[_]
 
-            # Check if the step is a Grype action
-            startswith(step.uses, "anchore/scan-action@")
-        
-            # Check that the "with.image" field is set
-            step["with"]["image"] != ""
+          # Check if the step is a Grype action
+          startswith(step.uses, "anchore/scan-action@")
+
+          # Check that the "with.image" field is set
+          step["with"].image != ""
         }

--- a/rule-types/github/grype_github_action_scan_repo.yaml
+++ b/rule-types/github/grype_github_action_scan_repo.yaml
@@ -42,30 +42,33 @@ def:
       def: |
         package minder
 
+        import rego.v1
+
         default allow := false
+
         default message := "Grype GitHub Action is not enabled for repository scanning."
 
-        allow {
-            # List all workflows
-            workflows := file.ls("./.github/workflows")
+        allow if {
+          # List all workflows
+          workflows := file.ls("./.github/workflows")
 
-            # Read all workflows
-            some w
-            workflowstr := file.read(workflows[w])
+          # Read all workflows
+          some w
+          workflowstr := file.read(workflows[w])
 
-            workflow := yaml.unmarshal(workflowstr)
+          workflow := yaml.unmarshal(workflowstr)
 
-            # Iterate jobs
-            job := workflow.jobs[_]
+          # Iterate jobs
+          job := workflow.jobs[_]
 
-            # Iterate steps
-            step := job.steps[_]
+          # Iterate steps
+          step := job.steps[_]
 
-            # Check if the step is a Grype action
-            startswith(step.uses, "anchore/scan-action@")
-        
-            # Check that the "with.path" field is set
-            step["with"]["path"] != ""
+          # Check if the step is a Grype action
+          startswith(step.uses, "anchore/scan-action@")
+
+          # Check that the "with.path" field is set
+          step["with"].path != ""
         }
   remediate:
     type: pull_request

--- a/rule-types/github/no_binaries_in_repo.yaml
+++ b/rule-types/github/no_binaries_in_repo.yaml
@@ -35,8 +35,7 @@ def:
       def: |
         package minder
 
-        import future.keywords.in
-        import future.keywords.if
+        import rego.v1
 
         violations[{"msg": msg}] if {
           # Walk all files in the repo

--- a/rule-types/github/no_open_security_advisories.yaml
+++ b/rule-types/github/no_open_security_advisories.yaml
@@ -66,48 +66,46 @@ def:
       violation_format: json
       def: |
         package minder
-        
-        import future.keywords.contains
-        import future.keywords.if
-        import future.keywords.in
-        
+
+        import rego.v1
+
         severity_to_number := {
-        	null: -1,
-        	"unknown": -1,
-        	"low": 0,
-        	"medium": 1,
-        	"high": 2,
-        	"critical": 3,
+          null: -1,
+          "unknown": -1,
+          "low": 0,
+          "medium": 1,
+          "high": 2,
+          "critical": 3,
         }
-        
+
         default threshold := 1
-        
+
         threshold := severity_to_number[input.profile.severity] if input.profile.severity != null
-        
+
         above_threshold(severity, threshold) if {
-        	severity_to_number[severity] >= threshold
+          severity_to_number[severity] >= threshold
         }
-        
+
         had_fallback if {
-        	input.ingested.fallback
+          input.ingested.fallback
         }
-        
+
         violations contains {"msg": "Security advisories not enabled."} if {
-        	had_fallback
+          had_fallback
         }
-        
+
         violations contains {"msg": "Found open security advisories in or above threshold"} if {
-        	not had_fallback
-        
-        	some adv in input.ingested
-        
-        	# Is not withdrawn
-        	adv.withdrawn_at == null
-        
-        	not adv.state in {"closed", "published", "draft"}
-        
-        	# We only care about advisories that are at or above the threshold
-        	above_threshold(adv.severity, threshold)
+          not had_fallback
+
+          some adv in input.ingested
+
+          # Is not withdrawn
+          adv.withdrawn_at == null
+
+          not adv.state in {"closed", "published", "draft"}
+
+          # We only care about advisories that are at or above the threshold
+          above_threshold(adv.severity, threshold)
         }
   alert:
     type: security_advisory

--- a/rule-types/github/openssf_bestpractices.yaml
+++ b/rule-types/github/openssf_bestpractices.yaml
@@ -53,12 +53,14 @@ def:
       type: deny-by-default
       def: |
         package minder
+
         import rego.v1
 
         default allow := false
+
         default message := "OpenSSF Best Practices Badge is missing"
 
-        levels := { "in_progress": 1, "passing": 2, "silver": 3, "gold": 4 }
+        levels := {"in_progress": 1, "passing": 2, "silver": 3, "gold": 4}
 
         allow if {
           file.exists(input.profile.filename)
@@ -67,7 +69,7 @@ def:
           badge := regex.find_all_string_submatch_n(`\[[^\]]+\]\(https:\/\/www\.bestpractices\.dev\/projects\/([\d]+)\/badge\)`, readme, 1)
           project_id := badge[0][1]
 
-          badge_data := minder.datasource.openssf_bestpractices.lookup({"id": project_id })
+          badge_data := minder.datasource.openssf_bestpractices.lookup({"id": project_id})
 
           levels[badge_data.body.badge_level] >= levels[input.profile.level]
         }

--- a/rule-types/github/permissive_license.yaml
+++ b/rule-types/github/permissive_license.yaml
@@ -41,16 +41,15 @@ def:
       def: |
         package minder
 
-        import future.keywords.every
-        import future.keywords.if
+        import rego.v1
 
-        violations[{"msg": msg}] {
+        violations contains {"msg": msg} if {
           license := input.ingested.license.spdx_id
 
           resp2 := minder.datasource.spdx.licenses({})
           licenses := resp2.body.licenses
-          osi := { l.licenseId | l := licenses[_]; l.isOsiApproved }
-          fsf := { l.licenseId | l := licenses[_]; l.isFsfLibre }
+          osi := {l.licenseId | l := licenses[_]; l.isOsiApproved}
+          fsf := {l.licenseId | l := licenses[_]; l.isFsfLibre}
           approved_licenses := osi | fsf
 
           count(approved_licenses) != 0

--- a/rule-types/github/repo_action_allow_list.yaml
+++ b/rule-types/github/repo_action_allow_list.yaml
@@ -45,24 +45,26 @@ def:
       def: |
         package minder
 
+        import rego.v1
+
         expected_set := {x | x := input.profile.actions[_]}
         actions := github_workflow.ls_actions("./.github/workflows")
 
-        violations[{"msg": msg}] {
+        violations contains {"msg": msg} if {
           extra := actions - expected_set
           not count(extra) == 0
           msg = format_message(extra, input.output_format)
         }
 
-        format_message(difference, format) = msg {
-            format == "json"
-            json_body := {"actions_not_allowed": difference}
-            msg := json.marshal(json_body)
+        format_message(difference, format) := msg if {
+          format == "json"
+          json_body := {"actions_not_allowed": difference}
+          msg := json.marshal(json_body)
         }
 
-        format_message(difference, format) = msg {
-            not format == "json"
-            msg := sprintf("extra actions found in workflows but not allowed in the profile: %v", [difference])
+        format_message(difference, format) := msg if {
+          not format == "json"
+          msg := sprintf("extra actions found in workflows but not allowed in the profile: %v", [difference])
         }
   # Defines the configuration for alerting on the rule
   alert:

--- a/rule-types/github/repo_visibility.yaml
+++ b/rule-types/github/repo_visibility.yaml
@@ -63,13 +63,15 @@ def:
       def: |
         package minder
 
+        import rego.v1
+
         default allow := false
+
         default message := "Repository visibility does not match the required setting"
 
-        allow {
+        allow if {
           input.ingested.visibility == input.profile.visibility
         }
-
   # Defines the configuration for alerting on the rule
   alert:
     type: security_advisory

--- a/rule-types/github/scorecard_enabled.yaml
+++ b/rule-types/github/scorecard_enabled.yaml
@@ -61,23 +61,26 @@ def:
       def: |
         package minder
 
+        import rego.v1
+
         default allow := false
+
         default message := "Scorecard Action is not configured for any workflow"
 
-        allow {
-            # List all workflows
-            workflows := file.ls("./.github/workflows")
+        allow if {
+          # List all workflows
+          workflows := file.ls("./.github/workflows")
 
-            # Read all workflows
-            some w
-            workflowstr := file.read(workflows[w])
+          # Read all workflows
+          some w
+          workflowstr := file.read(workflows[w])
 
-            workflow := yaml.unmarshal(workflowstr)
+          workflow := yaml.unmarshal(workflowstr)
 
-            # Ensure a workflow contains the scorecard action
-            some i
-            steps := workflow.jobs.analyze.steps[i]
-            startswith(steps.uses, "ossf/scorecard-action@")
+          # Ensure a workflow contains the scorecard action
+          some i
+          steps := workflow.jobs.analyze.steps[i]
+          startswith(steps.uses, "ossf/scorecard-action@")
         }
   remediate:
     type: pull_request

--- a/rule-types/github/secret_push_protection.yaml
+++ b/rule-types/github/secret_push_protection.yaml
@@ -57,10 +57,12 @@ def:
       def: |
         package minder
 
-        import future.keywords.if
+        import rego.v1
 
         default allow := false
+
         default skip := false
+
         default message := "Secret push protection is disabled"
 
         allow if {

--- a/rule-types/github/secret_scanning.yaml
+++ b/rule-types/github/secret_scanning.yaml
@@ -56,10 +56,12 @@ def:
       def: |
         package minder
 
-        import future.keywords.if
+        import rego.v1
 
         default allow := false
+
         default skip := false
+
         default message := "Secret scanning is disabled"
 
         allow if {

--- a/rule-types/github/security_insights.yaml
+++ b/rule-types/github/security_insights.yaml
@@ -52,11 +52,13 @@ def:
       type: deny-by-default
       def: |
         package minder
+
         import rego.v1
 
         default allow := false
+
         default message := "Security Insights file is missing"
-        
+
         allow if {
           file.exists(input.profile.filename)
         }

--- a/rule-types/github/security_insights_dep_policy.yaml
+++ b/rule-types/github/security_insights_dep_policy.yaml
@@ -56,12 +56,14 @@ def:
       type: deny-by-default
       def: |
         package minder
+
         import rego.v1
 
         default allow := false
+
         default message := "Dependency policy is missing from the Security Insights file"
-        
-        allow if {  
+
+        allow if {
           file.exists(input.profile.filename)
           sifile := file.read(input.profile.filename)
           si := yaml.unmarshal(sifile)

--- a/rule-types/github/security_policy.yaml
+++ b/rule-types/github/security_policy.yaml
@@ -37,15 +37,16 @@ def:
       type: deny-by-default
       def: |
         package minder
+
         import rego.v1
 
         default allow := false
+
         default message := "Security policy file is missing"
-        
+
         allow if {
           file.exists(input.profile.filename)
         }
-  
   # We don't have a remediation method in place yet.
   
   # Defines the configuration for alerting on the rule

--- a/rule-types/github/source_code_is_public.yaml
+++ b/rule-types/github/source_code_is_public.yaml
@@ -30,13 +30,12 @@ def:
       def: |
         package minder
 
-        import future.keywords.every
-        import future.keywords.if
+        import rego.v1
 
         default allow := false
 
         allow if {
           # This rule checks whether the repository is private using
           # info tied to the entity itself.
-          not input.properties["is_private"]
+          not input.properties.is_private
         }

--- a/rule-types/github/talisman_secrets_scanning.yaml
+++ b/rule-types/github/talisman_secrets_scanning.yaml
@@ -28,23 +28,23 @@ def:
       type: deny-by-default
       def: |
         package minder
-        import future.keywords.if
-        import future.keywords.every
+
+        import rego.v1
 
         default message := "Talisman pre-commit hook is not configured for the repository"
+
         default allow := false
 
-        
         # pre-commit hook
         precommit := file.read(".pre-commit-config.yaml")
-        
+
         parsed_data := parse_yaml(precommit)
 
-         allow if {
+        allow if {
           some repo_id, hook_id
           repo_data := parsed_data.repos[repo_id]
-          endswith(repo_data["repo"], "https://github.com/thoughtworks/talisman")
-          talisman_hooks = repo_data["hooks"]
+          endswith(repo_data.repo, "https://github.com/thoughtworks/talisman")
+          talisman_hooks = repo_data.hooks
           talisman_hooks[hook_id].id == "talisman-commit"
           talisman_hooks[hook_id].entry == "cmd --githook pre-commit"
         }

--- a/rule-types/github/trivy_action_enabled.yaml
+++ b/rule-types/github/trivy_action_enabled.yaml
@@ -53,27 +53,30 @@ def:
       def: |
         package minder
 
+        import rego.v1
+
         default allow := false
+
         default message := "Trivy action is not enabled"
 
-        allow {
-            # List all workflows
-            workflows := file.ls("./.github/workflows")
+        allow if {
+          # List all workflows
+          workflows := file.ls("./.github/workflows")
 
-            # Read all workflows
-            some w
-            workflowstr := file.read(workflows[w])
+          # Read all workflows
+          some w
+          workflowstr := file.read(workflows[w])
 
-            workflow := yaml.unmarshal(workflowstr)
+          workflow := yaml.unmarshal(workflowstr)
 
-            # Iterate jobs
-            job := workflow.jobs[_]
+          # Iterate jobs
+          job := workflow.jobs[_]
 
-            # Iterate steps
-            step := job.steps[_]
+          # Iterate steps
+          step := job.steps[_]
 
-            # Check if the step is a trivy action
-            startswith(step.uses, "aquasecurity/trivy-action@")
+          # Check if the step is a trivy action
+          startswith(step.uses, "aquasecurity/trivy-action@")
         }
   # Defines the configuration for alerting on the rule
   alert:

--- a/rule-types/github/trufflehog_github_action.yaml
+++ b/rule-types/github/trufflehog_github_action.yaml
@@ -35,13 +35,15 @@ def:
       type: deny-by-default
       def: |
         package minder
-        
+
         import rego.v1
 
         actions := github_workflow.ls_actions("./.github/workflows")
 
         default message := "No TruffleHog GitHub action found for automated secret detection"
+
         default allow := false
+
         allow if {
           # check that there is a trufflehog action
           "trufflesecurity/trufflehog" in actions

--- a/rule-types/github/workflow_no_pull_request_target.yaml
+++ b/rule-types/github/workflow_no_pull_request_target.yaml
@@ -39,23 +39,25 @@ def:
       def: |
         package minder
 
+        import rego.v1
+
         # List all workflows
         workflows := file.ls("./.github/workflows")
 
         # Read all workflows and check for pull_request_target trigger
-        violations[{"msg": msg}] {
-            some w
+        violations contains {"msg": msg} if {
+          some w
 
-            # Read the workflow file
-            workflowstr := file.read(workflows[w])
-            parsed := parse_yaml(workflowstr)
+          # Read the workflow file
+          workflowstr := file.read(workflows[w])
+          parsed := parse_yaml(workflowstr)
 
-            jq_query := ".on | (type == \"string\" and . == \"pull_request_target\") or (type == \"object\" and has(\"pull_request_target\")) or (type == \"array\" and any(.[]; . == \"pull_request_target\"))"
+          jq_query := ".on | (type == \"string\" and . == \"pull_request_target\") or (type == \"object\" and has(\"pull_request_target\")) or (type == \"array\" and any(.[]; . == \"pull_request_target\"))"
 
-            jq.is_true(parsed, jq_query)
+          jq.is_true(parsed, jq_query)
 
-            # Construct violation message if "pull_request_target" is found
-            msg := sprintf("Workflow '%v' contains 'pull_request_target' trigger in its 'on' block", [workflows[w]])
+          # Construct violation message if "pull_request_target" is found
+          msg := sprintf("Workflow '%v' contains 'pull_request_target' trigger in its 'on' block", [workflows[w]])
         }
   remediate:
     type: pull_request

--- a/rule-types/github/workflow_pull_request.yaml
+++ b/rule-types/github/workflow_pull_request.yaml
@@ -31,23 +31,23 @@ def:
       def: |
         package minder
 
-        import future.keywords.if
+        import rego.v1
 
         # List all workflows
         workflows := file.ls("./.github/workflows")
 
         # Read all workflows and check for pull_request trigger
         allow if {
-            some w
+          some w
 
-            # Read the workflow file
-            workflowstr := file.read(workflows[w])
-            parsed := parse_yaml(workflowstr)
-            print(parsed)
+          # Read the workflow file
+          workflowstr := file.read(workflows[w])
+          parsed := parse_yaml(workflowstr)
+          print(parsed)
 
-            jq_query := ".on | (type == \"string\" and . == \"pull_request\") or (type == \"object\" and has(\"pull_request\")) or (type == \"array\" and any(.[]; . == \"pull_request\"))"
+          jq_query := ".on | (type == \"string\" and . == \"pull_request\") or (type == \"object\" and has(\"pull_request\")) or (type == \"array\" and any(.[]; . == \"pull_request\"))"
 
-            jq.is_true(parsed, jq_query)
+          jq.is_true(parsed, jq_query)
         }
   # Defines the configuration for alerting on the rule
   alert:

--- a/rule-types/gitlab/gitlab_dependency_scanning_enabled.yaml
+++ b/rule-types/gitlab/gitlab_dependency_scanning_enabled.yaml
@@ -39,10 +39,13 @@ def:
       def: |
         package minder
 
+        import rego.v1
+
         default allow := false
+
         default message := "GitLab Dependency Scanning is not enabled"
 
-        allow {
+        allow if {
           # Read the .gitlab-ci.yml file
           pipelinestr := file.read("./.gitlab-ci.yml")
 
@@ -54,4 +57,3 @@ def:
           # Check that one of the included templates is Dependency-Scanning.gitlab-ci.yml
           includes.template == "Jobs/Dependency-Scanning.gitlab-ci.yml"
         }
-

--- a/rule-types/gitlab/gitlab_pipeline_secret_detection_enabled.yaml
+++ b/rule-types/gitlab/gitlab_pipeline_secret_detection_enabled.yaml
@@ -32,10 +32,13 @@ def:
       def: |
         package minder
 
+        import rego.v1
+
         default allow := false
+
         default message := "GitLab Dependency Scanning is not enabled"
 
-        allow {
+        allow if {
           # Read the .gitlab-ci.yml file
           pipelinestr := file.read("./.gitlab-ci.yml")
 
@@ -45,4 +48,3 @@ def:
 
           includes.template == "Jobs/Secret-Detection.gitlab-ci.yml"
         }
-

--- a/rule-types/gitlab/gitlab_protect_branch.yaml
+++ b/rule-types/gitlab/gitlab_protect_branch.yaml
@@ -36,10 +36,13 @@ def:
       def: |
         package minder
 
+        import rego.v1
+
         default allow := false
+
         default message := "Branch is not set as protected"
 
-        allow {
+        allow if {
           # Check that there is at least one protected branch
           count(input.ingested) > 0
 
@@ -49,4 +52,3 @@ def:
           # Check that the branch is protected
           input.ingested[i].allow_force_push == false
         }
-

--- a/rule-types/gitlab/gitlab_require_merge_requests.yaml
+++ b/rule-types/gitlab/gitlab_require_merge_requests.yaml
@@ -38,10 +38,13 @@ def:
       def: |
         package minder
 
+        import rego.v1
+
         default allow := false
+
         default message := "Merge requests are not required"
 
-        allow {
+        allow if {
           # Check that there is at least one protected branch
           count(input.ingested) > 0
 
@@ -51,4 +54,3 @@ def:
           # Check that the access level is to "no one"
           input.ingested[_].push_access_levels[_].access_level == 0
         }
-

--- a/scripts/migrate-rego-v1.py
+++ b/scripts/migrate-rego-v1.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""Migrate embedded Rego rule definitions in YAML files to Rego v1 syntax."""
+
+from __future__ import annotations
+
+import argparse
+import pathlib
+import re
+import subprocess
+import sys
+import tempfile
+
+
+DEF_BLOCK_RE = re.compile(r"^(?P<indent>\s*)def:\s*\|(?P<chomp>[+-]?)\s*$")
+
+
+def yaml_files(paths: list[pathlib.Path]) -> list[pathlib.Path]:
+    files: list[pathlib.Path] = []
+    for path in paths:
+        if path.is_dir():
+            files.extend(sorted(path.rglob("*.yaml")))
+            files.extend(sorted(path.rglob("*.yml")))
+        elif path.suffix in {".yaml", ".yml"}:
+            files.append(path)
+    return sorted(set(files))
+
+
+def leading_spaces(line: str) -> int:
+    return len(line) - len(line.lstrip(" "))
+
+
+def extract_block(lines: list[str], start: int, parent_indent: int) -> tuple[list[str], int]:
+    block: list[str] = []
+    current = start
+    while current < len(lines):
+        line = lines[current]
+        if line.strip() and leading_spaces(line) <= parent_indent:
+            break
+        block.append(line)
+        current += 1
+    return block, current
+
+
+def dedent_block(block: list[str]) -> tuple[str, int]:
+    nonblank_indents = [leading_spaces(line) for line in block if line.strip()]
+    if not nonblank_indents:
+        return "", 0
+
+    block_indent = min(nonblank_indents)
+    source = "".join(
+        line[block_indent:] if len(line) >= block_indent else "\n"
+        for line in block
+    )
+    return source, block_indent
+
+
+def format_rego(source: str, opa: str) -> str:
+    with tempfile.NamedTemporaryFile("w+", suffix=".rego") as rego_file:
+        rego_file.write(source)
+        rego_file.flush()
+
+        result = subprocess.run(
+            [opa, "fmt", "--v0-v1", rego_file.name],
+            check=False,
+            text=True,
+            capture_output=True,
+        )
+
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr.strip() or result.stdout.strip())
+
+    formatted = result.stdout.expandtabs(2)
+    if not formatted.endswith("\n"):
+        formatted += "\n"
+    return formatted
+
+
+def indent_block(source: str, indent: int) -> list[str]:
+    prefix = " " * indent
+    return [
+        prefix + line if line.strip() else prefix.rstrip() + "\n"
+        for line in source.splitlines(True)
+    ]
+
+
+def migrate_file(path: pathlib.Path, opa: str, check: bool) -> bool:
+    original = path.read_text()
+    lines = original.splitlines(True)
+    migrated: list[str] = []
+    changed = False
+    index = 0
+
+    while index < len(lines):
+        line = lines[index]
+        match = DEF_BLOCK_RE.match(line)
+        if not match:
+            migrated.append(line)
+            index += 1
+            continue
+
+        parent_indent = len(match.group("indent"))
+        block, next_index = extract_block(lines, index + 1, parent_indent)
+        source, block_indent = dedent_block(block)
+
+        if not source.lstrip().startswith("package "):
+            migrated.append(line)
+            migrated.extend(block)
+            index = next_index
+            continue
+
+        formatted = format_rego(source, opa)
+        formatted_block = indent_block(formatted, block_indent)
+
+        migrated.append(line)
+        migrated.extend(formatted_block)
+        changed = changed or block != formatted_block
+        index = next_index
+
+    if not changed:
+        return False
+
+    if check:
+        return True
+
+    path.write_text("".join(migrated))
+    return True
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Run 'opa fmt --v0-v1' on Rego definitions embedded in YAML def blocks.",
+    )
+    parser.add_argument("paths", nargs="*", type=pathlib.Path, default=[pathlib.Path("rule-types")])
+    parser.add_argument("--opa", default="opa", help="Path to the opa binary.")
+    parser.add_argument("--check", action="store_true", help="Report files that would change without writing them.")
+    args = parser.parse_args()
+
+    changed_files: list[pathlib.Path] = []
+    for path in yaml_files(args.paths):
+        try:
+            if migrate_file(path, args.opa, args.check):
+                changed_files.append(path)
+        except RuntimeError as exc:
+            print(f"{path}: {exc}", file=sys.stderr)
+            return 1
+
+    for path in changed_files:
+        print(path)
+
+    if args.check and changed_files:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/security-baseline/rule-types/github/osps-ac-03-01.yaml
+++ b/security-baseline/rule-types/github/osps-ac-03-01.yaml
@@ -38,9 +38,11 @@ def:
       type: deny-by-default
       def: |
         package minder
+
         import rego.v1
 
         default allow := false
+
         msg := "Force pushes are allowed on the default branch"
 
         # The ingest endpoint checks the "classic" branch protection rule.
@@ -52,13 +54,13 @@ def:
         applied_rulesets := minder.datasource.baselineghapi.branch_protection_status({
           "owner": input.properties["github/repo_owner"],
           "repo": input.properties["github/repo_name"],
-          "branch": input.properties["github/default_branch"]
+          "branch": input.properties["github/default_branch"],
         })
-        allow if {  # also type: deletion
+
+        allow if { # also type: deletion
           some rule
           applied_rulesets[rule].type = "non_fast_forward"
         }
-
 remediate:
   type: rest
   rest:

--- a/security-baseline/rule-types/github/osps-ac-03-02.yaml
+++ b/security-baseline/rule-types/github/osps-ac-03-02.yaml
@@ -37,9 +37,11 @@ def:
       type: deny-by-default
       def: |
         package minder
+
         import rego.v1
 
         default allow := false
+
         msg := "Branch deletions are allowed on the default branch"
 
         allow if {
@@ -50,13 +52,13 @@ def:
         applied_rulesets := minder.datasource.baselineghapi.branch_protection_status({
           "owner": input.properties["github/repo_owner"],
           "repo": input.properties["github/repo_name"],
-          "branch": input.properties["github/default_branch"]
+          "branch": input.properties["github/default_branch"],
         })
+
         allow if {
           some rule
           applied_rulesets[rule].type = "deletion"
         }
-
 remediate:
   type: rest
   rest:

--- a/security-baseline/rule-types/github/osps-br-01-01.yaml
+++ b/security-baseline/rule-types/github/osps-br-01-01.yaml
@@ -45,12 +45,13 @@ def:
       type: constraints
       def: |
         package minder
+
         import rego.v1
 
         # Match both .yml and .yaml files
         workflows := array.concat(file.ls_glob("./.github/workflows/*.yml"), file.ls_glob("./.github/workflows/*.yaml"))
 
-        dangerous_triggers = ["pull_request_target", "workflow_run"]
+        dangerous_triggers := ["pull_request_target", "workflow_run"]
 
         # Look for dangerous triggers combined with checkout of user-controlled code.
         violations contains {"msg": msg} if {

--- a/security-baseline/rule-types/github/osps-br-01-02.yaml
+++ b/security-baseline/rule-types/github/osps-br-01-02.yaml
@@ -32,12 +32,13 @@ def:
       type: constraints
       def: |
         package minder
+
         import rego.v1
 
         # Match both .yml and .yaml files
         workflows := array.concat(file.ls_glob("./.github/workflows/*.yml"), file.ls_glob("./.github/workflows/*.yaml"))
 
-        dangerous_triggers = ["pull_request_target", "workflow_run"]
+        dangerous_triggers := ["pull_request_target", "workflow_run"]
 
         # Look for possible unquoted references
         violations contains {"msg": msg} if {

--- a/security-baseline/rule-types/github/osps-br-03-01.yaml
+++ b/security-baseline/rule-types/github/osps-br-03-01.yaml
@@ -36,6 +36,7 @@ def:
       type: deny-by-default
       def: |
         package minder
+
         import rego.v1
 
         default allow := false

--- a/security-baseline/rule-types/github/osps-br-03-02.yaml
+++ b/security-baseline/rule-types/github/osps-br-03-02.yaml
@@ -30,6 +30,7 @@ def:
       type: constraints
       def: |
         package minder
+
         import rego.v1
 
         # Currently, we assume that direct downloads are linked from a README

--- a/security-baseline/rule-types/github/osps-br-07-01.yaml
+++ b/security-baseline/rule-types/github/osps-br-07-01.yaml
@@ -36,6 +36,7 @@ def:
       type: deny-by-default
       def: |
         package minder
+
         import rego.v1
 
         default allow := false
@@ -45,14 +46,16 @@ def:
 
         allow if {
           content := file.read(".gitignore")
+
           # TODO: check for specific secret patterns
           "" != content
         }
 
         repo_settings := minder.datasource.baselineghapi.repo_config({
-            "owner": input.properties["github/repo_owner"],
-            "repo": input.properties["github/repo_name"]
-          }).body
+          "owner": input.properties["github/repo_owner"],
+          "repo": input.properties["github/repo_name"],
+        }).body
+
         allow if {
           repo_settings.security_and_analysis.secret_scanning_push_protection.status == "enabled"
         }

--- a/security-baseline/rule-types/github/osps-do-01-01.yaml
+++ b/security-baseline/rule-types/github/osps-do-01-01.yaml
@@ -64,7 +64,7 @@ def:
           # Check the GitHub homepage link
           out = minder.datasource.baselineghapi.repo_config({
             "owner": input.properties["github/repo_owner"],
-            "repo": input.properties["github/repo_name"]
+            "repo": input.properties["github/repo_name"],
           })
           out.body.homepage != ""
         }
@@ -75,7 +75,7 @@ def:
           rstDocs := file.ls_glob("docs/*.rst")
           htmlDocs := file.ls_glob("docs/*.html")
           txtDocs := file.ls_glob("docs/*.txt")
-          count(mdDocs) + count(rstDocs) + count(htmlDocs) + count(txtDocs) > 0
+          ((count(mdDocs) + count(rstDocs)) + count(htmlDocs)) + count(txtDocs) > 0
         }
 
         readme := file.read("README.md")
@@ -83,10 +83,10 @@ def:
           # Check the README.md file for preformatted text after the first line
           regex.match("\n *```", readme)
         }
+
         allow if {
           regex.match("\n#+ (?i:Usage|Getting Started)", readme)
         }
-
 # Remediation is a work in progress -- ideally, we could read which location(s)
 # contained the documentation, and automatically update SECURITY-INSIGHTS.yaml
 # with any missing documentation locations.

--- a/security-baseline/rule-types/github/osps-do-02-01.yaml
+++ b/security-baseline/rule-types/github/osps-do-02-01.yaml
@@ -33,8 +33,10 @@ def:
       type: deny-by-default
       def: |
         package minder
+
         import rego.v1
 
         default allow := false
+
         allow if input.ingested.has_issues
         allow if input.ingested.has_discussions

--- a/security-baseline/rule-types/github/osps-do-04-01.yaml
+++ b/security-baseline/rule-types/github/osps-do-04-01.yaml
@@ -29,12 +29,11 @@ def:
       def: |
         package minder
 
-        import future.keywords.every
-        import future.keywords.if
-        
+        import rego.v1
+
         readme_pattern := "./[Rr][Ee][Aa][Dd][Mm][Ee]*"
-        
-        # Check if the file contains "support" 
+
+        # Check if the file contains "support"
         has_support_header(file_path) if {
           file_path != null
           content := file.read(file_path)
@@ -51,7 +50,7 @@ def:
           content := file.read(files[name])
           "" != content
         }
-        
+
         # Check if the repository has a README file with a support header
         allow if {
           files := file.ls_glob(readme_pattern)
@@ -59,7 +58,7 @@ def:
           some name
           has_support_header(files[name])
         }
-        
+
         # Check if the repository has a SUPPORT.eox file
         allow if {
           files := file.ls_glob("/**/SUPPORT.eox")

--- a/security-baseline/rule-types/github/osps-gv-03-01.yaml
+++ b/security-baseline/rule-types/github/osps-gv-03-01.yaml
@@ -24,8 +24,7 @@ def:
       def: |
         package minder
 
-        import future.keywords.every
-        import future.keywords.if
+        import rego.v1
 
         default allow := false
 

--- a/security-baseline/rule-types/github/osps-le-02-01.yaml
+++ b/security-baseline/rule-types/github/osps-le-02-01.yaml
@@ -36,22 +36,21 @@ def:
       def: |
         package minder
 
-        import future.keywords.every
-        import future.keywords.if
+        import rego.v1
 
-        violations[{"msg": msg}] {
+        violations contains {"msg": msg} if {
           not input.ingested.license
           msg := "License details not found"
         }
 
-        violations[{"msg": msg}] {
+        violations contains {"msg": msg} if {
           input.ingested.license
           license := input.ingested.license.spdx_id
 
           resp2 := minder.datasource.spdx.licenses({})
           licenses := resp2.body.licenses
-          osi := { l.licenseId | l := licenses[_]; l.isOsiApproved }
-          fsf := { l.licenseId | l := licenses[_]; l.isFsfLibre }
+          osi := {l.licenseId | l := licenses[_]; l.isOsiApproved}
+          fsf := {l.licenseId | l := licenses[_]; l.isFsfLibre}
           approved_licenses := osi | fsf
 
           count(approved_licenses) != 0

--- a/security-baseline/rule-types/github/osps-le-02-02.yaml
+++ b/security-baseline/rule-types/github/osps-le-02-02.yaml
@@ -43,49 +43,47 @@ def:
         import rego.v1
 
         get_license_info(asset) := {"license_resp": license_resp, "ident_resp": ident_resp} if {
-            license_resp := http.send({
-                "method": "GET",
-                "url": asset.browser_download_url,
-                "headers": {
-                    "Accept": "application/octet-stream"
-                },
-                "enable_redirect": true,
-                "raise_error": true
-            })
+          license_resp := http.send({
+            "method": "GET",
+            "url": asset.browser_download_url,
+            "headers": {"Accept": "application/octet-stream"},
+            "enable_redirect": true,
+            "raise_error": true,
+          })
 
-            ident_resp := http.send({
-                "method": "POST",
-                "url": "https://spdx-detector-562949304223.us-central1.run.app",
-                "headers": {
-                    "Accept": "application/json",
-                    "Content-Type": "text/plain"
-                },
-                "raw_body": license_resp.raw_body,
-                "raise_error": true
-            })
+          ident_resp := http.send({
+            "method": "POST",
+            "url": "https://spdx-detector-562949304223.us-central1.run.app",
+            "headers": {
+              "Accept": "application/json",
+              "Content-Type": "text/plain",
+            },
+            "raw_body": license_resp.raw_body,
+            "raise_error": true,
+          })
         }
 
         get_approved_licenses(licenses) := approved_licenses if {
-            osi := {l.licenseId | l := licenses[_]; l.isOsiApproved}
-            fsf := {l.licenseId | l := licenses[_]; l.isFsfLibre}
-            approved_licenses := osi | fsf
+          osi := {l.licenseId | l := licenses[_]; l.isOsiApproved}
+          fsf := {l.licenseId | l := licenses[_]; l.isFsfLibre}
+          approved_licenses := osi | fsf
         }
 
         violations contains {"msg": msg} if {
-            some asset in input.ingested
-            startswith(lower(asset.name), "license")
-            
-            resp := get_license_info(asset)
-            
-            msg := get_violation_message(resp)
+          some asset in input.ingested
+          startswith(lower(asset.name), "license")
+
+          resp := get_license_info(asset)
+
+          msg := get_violation_message(resp)
         }
 
         get_violation_message(resp) := "No valid license identified in the license file" if {
-            resp.ident_resp.body[0] == ""
+          resp.ident_resp.body[0] == ""
         } else := sprintf("License '%v' is not OSI/FSF approved", [license_id]) if {
-            count(resp.ident_resp.body) > 0
-            license_id := resp.ident_resp.body[0]
-            spdx_resp := minder.datasource.spdx.licenses({})
-            approved_licenses := get_approved_licenses(spdx_resp.body.licenses)
-            not license_id in approved_licenses
+          count(resp.ident_resp.body) > 0
+          license_id := resp.ident_resp.body[0]
+          spdx_resp := minder.datasource.spdx.licenses({})
+          approved_licenses := get_approved_licenses(spdx_resp.body.licenses)
+          not license_id in approved_licenses
         }

--- a/security-baseline/rule-types/github/osps-le-03-01.yaml
+++ b/security-baseline/rule-types/github/osps-le-03-01.yaml
@@ -24,8 +24,7 @@ def:
       def: |
         package minder
 
-        import future.keywords.every
-        import future.keywords.if
+        import rego.v1
 
         default allow := false
 

--- a/security-baseline/rule-types/github/osps-le-03-02.yaml
+++ b/security-baseline/rule-types/github/osps-le-03-02.yaml
@@ -34,7 +34,7 @@ def:
 
         import rego.v1
 
-        default allow = false
+        default allow := false
 
         # GitHub publishes the source code at `tarball_url`, which includes
         # the LICENSE in the repo, so we only need to check for an explicit

--- a/security-baseline/rule-types/github/osps-qa-01-01.yaml
+++ b/security-baseline/rule-types/github/osps-qa-01-01.yaml
@@ -31,8 +31,7 @@ def:
       def: |
         package minder
 
-        import future.keywords.every
-        import future.keywords.if
+        import rego.v1
 
         default allow := false
 

--- a/security-baseline/rule-types/github/osps-qa-01-02.yaml
+++ b/security-baseline/rule-types/github/osps-qa-01-02.yaml
@@ -42,6 +42,6 @@ def:
         default allow := false
 
         allow if {
-            not input.properties["is_private"]
-            not input.ingested.allow_force_pushes.enabled
+          not input.properties.is_private
+          not input.ingested.allow_force_pushes.enabled
         }

--- a/security-baseline/rule-types/github/osps-qa-02-01.yaml
+++ b/security-baseline/rule-types/github/osps-qa-02-01.yaml
@@ -32,16 +32,18 @@ def:
         import rego.v1
 
         default allow := false
+
         default skip := false
+
         default message := "Cannot find lockfile in the same directory as the package file"
-        
+
         package_manager_files := [
           {"name": "Gemfile", "lockfiles": ["Gemfile.lock"]},
           {"name": "go.mod", "lockfiles": ["go.sum"]},
           {"name": "package.json", "lockfiles": ["package-lock.json", "yarn.lock"]},
           {"name": "Cargo.toml", "lockfiles": ["Cargo.lock"]},
         ]
-        
+
         skip if {
           # Skip if no package manager file exists
           every package_manager in package_manager_files {
@@ -49,23 +51,22 @@ def:
             count(required_files) == 0
           }
         }
-        
+
         allow if {
           # Ensure that we find the required file
           some package_manager in package_manager_files
           package_files := file.ls_glob(sprintf("./%s", [package_manager.name]))
           count(package_files) > 0
-        
+
           # Get the directory for the package file
           some package_path in package_files
           dir := trim_suffix(package_path, sprintf("/%s", [package_manager.name]))
-        
+
           # Ensure a lockfile exists for the required file in the same directory
-          lockfile_exists(dir, package_manager.lockfiles) 
+          lockfile_exists(dir, package_manager.lockfiles)
         }
-        
+
         lockfile_exists(dir, lockfiles) if {
           some lockfile in lockfiles
           count(file.ls_glob(sprintf("%s/%s", [dir, lockfile]))) > 0
         }
-

--- a/security-baseline/rule-types/github/osps-qa-05-01.yaml
+++ b/security-baseline/rule-types/github/osps-qa-05-01.yaml
@@ -29,11 +29,12 @@ def:
       type: constraints
       def: |
         package minder
+
         import rego.v1
 
         # N.B. creating this test case in a test would cause this repo to fail the check,
         # so we do not have this test case yet.
-        violations contains{"msg": msg} if {
+        violations contains {"msg": msg} if {
           # Walk all files in the repo
           files_in_repo := file.walk(".")
 

--- a/security-baseline/rule-types/github/osps-qa-05-02.yaml
+++ b/security-baseline/rule-types/github/osps-qa-05-02.yaml
@@ -30,6 +30,7 @@ def:
       type: constraints
       def: |
         package minder
+
         import rego.v1
 
         permitted_prefixes := [
@@ -47,7 +48,7 @@ def:
 
         # N.B. creating this test case in a test would cause this repo to fail the check,
         # so we do not have this test case yet.
-        violations contains{"msg": msg} if {
+        violations contains {"msg": msg} if {
           # Walk all files in the repo
           files_in_repo := file.walk(".")
 
@@ -58,4 +59,3 @@ def:
 
           msg := sprintf("Unreviewable artifact found: %s of type %s", [current_file, http_type])
         }
-

--- a/security-baseline/rule-types/github/osps-vm-05-01.yaml
+++ b/security-baseline/rule-types/github/osps-vm-05-01.yaml
@@ -42,15 +42,15 @@ def:
 
         # Allow if SECURITY.md exists and contains "report"
         allow if {
-            # Search specifically for SECURITY.md
-            files := file.ls_glob("./SECURITY*")
-            count(files) > 0
+          # Search specifically for SECURITY.md
+          files := file.ls_glob("./SECURITY*")
+          count(files) > 0
 
-            # Read the content of the file
-            content := lower(file.read(files[0]))
-            
-            # Check if "report" exists in the content
-            contains(content, "report")
+          # Read the content of the file
+          content := lower(file.read(files[0]))
+
+          # Check if "report" exists in the content
+          contains(content, "report")
         }
 
         # Allow if GitHub vulnerability reporting is enabled
@@ -58,8 +58,9 @@ def:
           # Query the GitHub API to check vulnerability reporting status
           out = minder.datasource.baselineghapi.private_vuln_reporting({
             "owner": input.properties["github/repo_owner"],
-            "repo": input.properties["github/repo_name"]
+            "repo": input.properties["github/repo_name"],
           })
+
           # Ensure private vulnerability reporting is enabled
           out.body.enabled == true
         }


### PR DESCRIPTION
## Summary

This PR migrates the Rego policies in `minder-rules-and-profiles` to Rego v1 syntax as Phase 2 of the Rego v1 migration work from mindersec/minder#5262.
Child issue mindersec/minder#6463

It adds a reusable migration helper that extracts embedded YAML `def: |` policy blocks, runs `opa fmt --v0-v1`, and writes the formatted Rego back into place. The migration also updates docs/examples so downstream users have a repeatable path for their own rule type YAML.

## What changed

- Added `scripts/migrate-rego-v1.py` and a `task migrate-rego-v1` target.
- Migrated embedded Rego policies in rule types, security-baseline rule types, and autofill-insights rule types to `import rego.v1`.
- Removed `future.keywords` usage from policy docs and examples.
- Kept the migration script idempotent and whitespace-safe for YAML block scalars.

## Validation

- `python3 scripts/migrate-rego-v1.py --check .`
- `git diff --check`
- `go test ./...`

## Notes for reviewers

This should be a syntax-only migration. Any policy behavior change should be treated as unintended unless called out during review.