### PR TITLE
feat: add OSPS security baseline rule types for GitLab

### DIFF
--- a/security-baseline/rule-types/gitlab/osps-br-03-02.yaml
+++ b/security-baseline/rule-types/gitlab/osps-br-03-02.yaml
@@ -1,0 +1,47 @@
+version: v1
+release_phase: alpha
+type: rule-type
+name: osps-br-03-02 
+display_name: Deliver releases via encrypted channels
+short_failure_message: Releases available via unsecured channels
+severity:
+  value: high
+context:
+  provider: gitlab
+description: |
+  This check determines whether the release artifacts of the project
+  are delived via unsecured (unencrypted) channels.
+
+  Downloading release artifacts via unsecured channels is a supply
+  chain risk for consumers, as attackers could compromise the release
+  assets in-transit via a Machine-in-the-Middle (MitM) attack.
+
+guidance: |
+  Deliver artifacts using HTTPS URLs or package repositories.
+def:
+  in_entity: repository
+  rule_schema: {}
+  ingest:
+    type: git
+  eval:
+    # We only need to worry about links in e.g. the README, as artifacts
+    # distributed via GitHub releases or package repositories will already
+    # be encrypted.
+    type: rego
+    rego:
+      type: constraints
+      def: |
+        package minder
+        import rego.v1
+
+        # Currently, we assume that direct downloads are linked from a README
+        # file, and not elsewhere in the documentation.
+        readme_contents := file.read("./README.md")
+        http_urls := regex.find_all_string_submatch_n(`(http://\S*)`, readme_contents, -1)[0]
+
+        violations contains {"msg": msg} if {
+          some url in http_urls
+          not startswith(url, "http://localhost")
+
+          msg := sprintf("README.md contains non-HTTPS URL '%s'", [url])
+        }

--- a/security-baseline/rule-types/gitlab/osps-gv-03-01.yaml
+++ b/security-baseline/rule-types/gitlab/osps-gv-03-01.yaml
@@ -25,24 +25,11 @@ def:
       type: deny-by-default
       def: |
         package minder
-
-        import future.keywords.every
-        import future.keywords.if
-
+        import rego.v1
         default allow := false
-
         allow if {
           files := file.ls_glob("./CONTRIBUTING*")
-
           some name
           content := file.read(files[name])
-          "" != content
-        }
-
-        allow if {
-          files := file.ls_glob("./CONTRIBUTING/*")
-
-          some name
-          content := file.read(files[name])
-          "" != content
+          content != ""
         }

--- a/security-baseline/rule-types/gitlab/osps-gv-03-01.yaml
+++ b/security-baseline/rule-types/gitlab/osps-gv-03-01.yaml
@@ -1,0 +1,48 @@
+version: v1
+release_phase: alpha
+type: rule-type
+name: osps-gv-03-01
+display_name: Contribution process is explained
+short_failure_message: No CONTRIBUTING file or folder was found
+severity:
+  value: info
+context:
+  provider: gitlab
+description: |
+  Ensure that either a CONTRIBUTING file or CONTRIBUTING/ folder is
+  available.
+guidance: |
+  Source code must be accompanied by a `CONTRIBUTING` file or a
+  `CONTRIBUTING/` folder at the root of the project source tree.
+def:
+  in_entity: repository
+  rule_schema: {}
+  ingest:
+    type: git
+  eval:
+    type: rego
+    rego:
+      type: deny-by-default
+      def: |
+        package minder
+
+        import future.keywords.every
+        import future.keywords.if
+
+        default allow := false
+
+        allow if {
+          files := file.ls_glob("./CONTRIBUTING*")
+
+          some name
+          content := file.read(files[name])
+          "" != content
+        }
+
+        allow if {
+          files := file.ls_glob("./CONTRIBUTING/*")
+
+          some name
+          content := file.read(files[name])
+          "" != content
+        }

--- a/security-baseline/rule-types/gitlab/osps-le-03-01.yaml
+++ b/security-baseline/rule-types/gitlab/osps-le-03-01.yaml
@@ -25,32 +25,17 @@ def:
       type: deny-by-default
       def: |
         package minder
-
-        import future.keywords.every
-        import future.keywords.if
-
+        import rego.v1
         default allow := false
-
         allow if {
           files := file.ls_glob("./LICENSE*")
-
           some name
           content := file.read(files[name])
-          "" != content
+          content != ""
         }
-
         allow if {
           files := file.ls_glob("./COPYING*")
-
           some name
           content := file.read(files[name])
-          "" != content
-        }
-
-        allow if {
-          files := file.ls_glob("./LICENSE/*")
-
-          some name
-          content := file.read(files[name])
-          "" != content
+          content != ""
         }

--- a/security-baseline/rule-types/gitlab/osps-le-03-01.yaml
+++ b/security-baseline/rule-types/gitlab/osps-le-03-01.yaml
@@ -1,0 +1,56 @@
+version: v1
+release_phase: alpha
+type: rule-type
+name: osps-le-03-01
+display_name: LICENSE or COPYING files are available
+short_failure_message: No LICENSE or COPYING file found.
+severity:
+  value: info
+context:
+  provider: gitlab
+description: |
+  Ensure that either LICENSE file, COPYING file, or LICENSE/ folder
+  are available.
+guidance: |
+  Source code must be accompanied by a `LICENSE` or `COPYING` file, or
+  a `LICENSE/` folder at the root of the project source tree.
+def:
+  in_entity: repository
+  rule_schema: {}
+  ingest:
+    type: git
+  eval:
+    type: rego
+    rego:
+      type: deny-by-default
+      def: |
+        package minder
+
+        import future.keywords.every
+        import future.keywords.if
+
+        default allow := false
+
+        allow if {
+          files := file.ls_glob("./LICENSE*")
+
+          some name
+          content := file.read(files[name])
+          "" != content
+        }
+
+        allow if {
+          files := file.ls_glob("./COPYING*")
+
+          some name
+          content := file.read(files[name])
+          "" != content
+        }
+
+        allow if {
+          files := file.ls_glob("./LICENSE/*")
+
+          some name
+          content := file.read(files[name])
+          "" != content
+        }

--- a/security-baseline/rule-types/gitlab/osps-qa-02-01.yaml
+++ b/security-baseline/rule-types/gitlab/osps-qa-02-01.yaml
@@ -1,0 +1,73 @@
+---
+version: v1
+release_phase: alpha
+type: rule-type
+name: osps-qa-02-01
+display_name: Package management file listing dependencies is present
+short_failure_message: No package management file listing dependencies was found
+severity:
+  value: info
+context:
+  provider: gitlab
+description: |
+  This rule ensures that the repository provides a dependency list that accounts 
+  for the direct language dependencies when the package management system supports it.
+  It checks for the presence of a Gemfile.lock, go.sum, package-lock.json or 
+  Cargo.toml according to the package management system used.
+guidance: |
+  Ensure that the repository provides a dependency list that accounts for the direct
+  language dependencies in the form of a lockfile, for example Gemfile.lock, go.sum,
+  package-lock.json etc.
+  Ensure the lockfile is in the same directory as the package file.
+def:
+  in_entity: repository
+  rule_schema: {}
+  ingest:
+    type: git
+  eval:
+    type: rego
+    rego:
+      type: deny-by-default
+      def: |
+        package minder
+
+        import rego.v1
+
+        default allow := false
+        default skip := false
+        default message := "Cannot find lockfile in the same directory as the package file"
+        
+        package_manager_files := [
+          {"name": "Gemfile", "lockfiles": ["Gemfile.lock"]},
+          {"name": "go.mod", "lockfiles": ["go.sum"]},
+          {"name": "package.json", "lockfiles": ["package-lock.json", "yarn.lock"]},
+          {"name": "Cargo.toml", "lockfiles": ["Cargo.lock"]},
+        ]
+        
+        skip if {
+          # Skip if no package manager file exists
+          every package_manager in package_manager_files {
+            required_files := file.ls_glob(sprintf("./%s", [package_manager.name]))
+            count(required_files) == 0
+          }
+        }
+        
+        allow if {
+          # Ensure that we find the required file
+          some package_manager in package_manager_files
+          package_files := file.ls_glob(sprintf("./%s", [package_manager.name]))
+          count(package_files) > 0
+        
+          # Get the directory for the package file
+          some package_path in package_files
+          dir := trim_suffix(package_path, sprintf("/%s", [package_manager.name]))
+        
+          # Ensure a lockfile exists for the required file in the same directory
+          lockfile_exists(dir, package_manager.lockfiles) 
+        }
+        
+        lockfile_exists(dir, lockfiles) if {
+          some lockfile in lockfiles
+          count(file.ls_glob(sprintf("%s/%s", [dir, lockfile]))) > 0
+        }
+

--- a/security-baseline/rule-types/gitlab/osps-qa-05-01.yaml
+++ b/security-baseline/rule-types/gitlab/osps-qa-05-01.yaml
@@ -1,0 +1,48 @@
+---
+version: v1
+release_phase: alpha
+type: rule-type
+name: osps-qa-05-01
+display_name: Version control does not contain generated executable artifacts
+short_failure_message: Binary artifacts found in the repository
+severity:
+  value: high
+context:
+  provider: gitlab
+description: |
+  This rule ensures that the repository does not contain any generated executable
+  artifacts.  It is difficult to review and ascertain the provenance of binary
+  artifacts; instead, they should be generated at build time or stored in a separate
+  store (such as a package repository) and fetched during specific well-documented
+  pipeline steps.
+guidance: |
+  Replace executable binary artifacts in the repository with build pipeline scripts
+  which install the necessary commands after validating their authenticity (for
+  example, by verifying checksums or signatures).
+def:
+  in_entity: repository
+  rule_schema: {}
+  ingest:
+    type: git
+    git:
+  eval:
+    type: rego
+    rego:
+      type: constraints
+      def: |
+        package minder
+        import rego.v1
+
+        # N.B. creating this test case in a test would cause this repo to fail the check,
+        # so we do not have this test case yet.
+        violations contains{"msg": msg} if {
+          # Walk all files in the repo
+          files_in_repo := file.walk(".")
+
+          some current_file in files_in_repo
+
+          http_type := file.http_type(current_file)
+          http_type == "application/octet-stream"
+
+          msg := sprintf("Binary artifact found: %s", [current_file])
+        }

--- a/security-baseline/rule-types/gitlab/osps-qa-05-02.yaml
+++ b/security-baseline/rule-types/gitlab/osps-qa-05-02.yaml
@@ -1,0 +1,63 @@
+---
+version: v1
+release_phase: alpha
+type: rule-type
+name: osps-qa-05-02
+display_name: Version control does not contain binary artifacts
+short_failure_message: Binary artifacts found in the repository
+severity:
+  value: high
+context:
+  provider: gitlab
+description: |
+  This rule ensures that the repository does not contain any unreviewable
+  binary artifacts.  It is difficult to review and ascertain the provenance
+  of binary artifacts such as application binaries or compressed archives.
+
+  This prohibition does not include files which are commonly used to store
+  images, sound, or other media assets, which can generally be reviewed
+  using standard tools.
+guidance: |
+  Avoid storing artifacts for uncommon file types which cannot easily be
+  reviewed.
+def:
+  in_entity: repository
+  rule_schema: {}
+  ingest:
+    type: git
+    git:
+  eval:
+    type: rego
+    rego:
+      type: constraints
+      def: |
+        package minder
+        import rego.v1
+
+        permitted_prefixes := [
+          "image/",
+          "audio/",
+          "video/",
+          "text/",
+          "application/pdf",
+        ]
+
+        permitted_type(http_type) if {
+          some prefix in permitted_prefixes
+          startswith(http_type, prefix)
+        }
+
+        # N.B. creating this test case in a test would cause this repo to fail the check,
+        # so we do not have this test case yet.
+        violations contains{"msg": msg} if {
+          # Walk all files in the repo
+          files_in_repo := file.walk(".")
+
+          some current_file in files_in_repo
+
+          http_type := file.http_type(current_file)
+          not permitted_type(http_type)
+
+          msg := sprintf("Unreviewable artifact found: %s of type %s", [current_file, http_type])
+        }
+


### PR DESCRIPTION
Port 6 OSPS Security Baseline level-1 rules to GitLab
Adds GitLab versions of 6 OSPS Baseline level-1 rules that use git ingest (clone-based file checks with no GitHub API calls). These rules work identically with GitLab repositories — the only change from the GitHub versions is context: provider: gitlab.
Rules added:

osps-br-03-02: Deliver releases via encrypted channels
osps-gv-03-01: Enforce CONTRIBUTING file presence
osps-le-03-01: LICENSE or COPYING files are available
osps-qa-02-01: Source code contains direct dependency list
osps-qa-05-01: No generated executable artifacts in VCS
osps-qa-05-02: No unreviewable binary artifacts in VCS

Part of the GitLab provider coverage work tracked in mindersec/minder#6435.
The remaining 15 level-1 rules use GitHub REST API endpoints and will need separate GitLab API equivalents in follow-up PRs.