### PR TITLE
fix: remove context.provider from git-ingest OSPS baseline rules

### DIFF
--- a/security-baseline/rule-types/github/osps-br-03-02.yaml
+++ b/security-baseline/rule-types/github/osps-br-03-02.yaml
@@ -6,6 +6,7 @@ display_name: Deliver releases via encrypted channels
 short_failure_message: Releases available via unsecured channels
 severity:
   value: high
+description: |
   This check determines whether the release artifacts of the project
   are delived via unsecured (unencrypted) channels.
 

--- a/security-baseline/rule-types/github/osps-br-03-02.yaml
+++ b/security-baseline/rule-types/github/osps-br-03-02.yaml
@@ -6,9 +6,6 @@ display_name: Deliver releases via encrypted channels
 short_failure_message: Releases available via unsecured channels
 severity:
   value: high
-context:
-  provider: github
-description: |
   This check determines whether the release artifacts of the project
   are delived via unsecured (unencrypted) channels.
 

--- a/security-baseline/rule-types/github/osps-gv-03-01.yaml
+++ b/security-baseline/rule-types/github/osps-gv-03-01.yaml
@@ -6,6 +6,7 @@ display_name: Contribution process is explained
 short_failure_message: No CONTRIBUTING file or folder was found
 severity:
   value: info
+description: |
   Ensure that either a CONTRIBUTING file or CONTRIBUTING/ folder is
   available.
 guidance: |

--- a/security-baseline/rule-types/github/osps-gv-03-01.yaml
+++ b/security-baseline/rule-types/github/osps-gv-03-01.yaml
@@ -6,9 +6,6 @@ display_name: Contribution process is explained
 short_failure_message: No CONTRIBUTING file or folder was found
 severity:
   value: info
-context:
-  provider: github
-description: |
   Ensure that either a CONTRIBUTING file or CONTRIBUTING/ folder is
   available.
 guidance: |

--- a/security-baseline/rule-types/github/osps-le-03-01.yaml
+++ b/security-baseline/rule-types/github/osps-le-03-01.yaml
@@ -6,9 +6,6 @@ display_name: LICENSE or COPYING files are available
 short_failure_message: No LICENSE or COPYING file found.
 severity:
   value: info
-context:
-  provider: github
-description: |
   Ensure that either LICENSE file, COPYING file, or LICENSE/ folder
   are available.
 guidance: |

--- a/security-baseline/rule-types/github/osps-le-03-01.yaml
+++ b/security-baseline/rule-types/github/osps-le-03-01.yaml
@@ -6,6 +6,7 @@ display_name: LICENSE or COPYING files are available
 short_failure_message: No LICENSE or COPYING file found.
 severity:
   value: info
+description: |
   Ensure that either LICENSE file, COPYING file, or LICENSE/ folder
   are available.
 guidance: |

--- a/security-baseline/rule-types/github/osps-qa-02-01.yaml
+++ b/security-baseline/rule-types/github/osps-qa-02-01.yaml
@@ -7,9 +7,6 @@ display_name: Package management file listing dependencies is present
 short_failure_message: No package management file listing dependencies was found
 severity:
   value: info
-context:
-  provider: github
-description: |
   This rule ensures that the repository provides a dependency list that accounts 
   for the direct language dependencies when the package management system supports it.
   It checks for the presence of a Gemfile.lock, go.sum, package-lock.json or 

--- a/security-baseline/rule-types/github/osps-qa-02-01.yaml
+++ b/security-baseline/rule-types/github/osps-qa-02-01.yaml
@@ -7,6 +7,7 @@ display_name: Package management file listing dependencies is present
 short_failure_message: No package management file listing dependencies was found
 severity:
   value: info
+description: |
   This rule ensures that the repository provides a dependency list that accounts 
   for the direct language dependencies when the package management system supports it.
   It checks for the presence of a Gemfile.lock, go.sum, package-lock.json or 

--- a/security-baseline/rule-types/github/osps-qa-05-01.yaml
+++ b/security-baseline/rule-types/github/osps-qa-05-01.yaml
@@ -7,9 +7,6 @@ display_name: Version control does not contain generated executable artifacts
 short_failure_message: Binary artifacts found in the repository
 severity:
   value: high
-context:
-  provider: github
-description: |
   This rule ensures that the repository does not contain any generated executable
   artifacts.  It is difficult to review and ascertain the provenance of binary
   artifacts; instead, they should be generated at build time or stored in a separate

--- a/security-baseline/rule-types/github/osps-qa-05-01.yaml
+++ b/security-baseline/rule-types/github/osps-qa-05-01.yaml
@@ -7,6 +7,7 @@ display_name: Version control does not contain generated executable artifacts
 short_failure_message: Binary artifacts found in the repository
 severity:
   value: high
+description: |
   This rule ensures that the repository does not contain any generated executable
   artifacts.  It is difficult to review and ascertain the provenance of binary
   artifacts; instead, they should be generated at build time or stored in a separate

--- a/security-baseline/rule-types/github/osps-qa-05-02.yaml
+++ b/security-baseline/rule-types/github/osps-qa-05-02.yaml
@@ -7,9 +7,6 @@ display_name: Version control does not contain binary artifacts
 short_failure_message: Binary artifacts found in the repository
 severity:
   value: high
-context:
-  provider: github
-description: |
   This rule ensures that the repository does not contain any unreviewable
   binary artifacts.  It is difficult to review and ascertain the provenance
   of binary artifacts such as application binaries or compressed archives.

--- a/security-baseline/rule-types/github/osps-qa-05-02.yaml
+++ b/security-baseline/rule-types/github/osps-qa-05-02.yaml
@@ -7,6 +7,7 @@ display_name: Version control does not contain binary artifacts
 short_failure_message: Binary artifacts found in the repository
 severity:
   value: high
+description: |
   This rule ensures that the repository does not contain any unreviewable
   binary artifacts.  It is difficult to review and ascertain the provenance
   of binary artifacts such as application binaries or compressed archives.


### PR DESCRIPTION
Since `context.provider` is ignored by Minder as of mindersec/minder#2843, having it set to `github` on rules that use only `git` ingest gives a false impression that these rules are GitHub-specific.
This removes the `context` block from 6 provider-agnostic level-1 rules that use git clone ingest with no GitHub API calls:

- `osps-br-03-02`: Deliver releases via encrypted channels
- `osps-gv-03-01`: Enforce CONTRIBUTING file presence
- `osps-le-03-01`: LICENSE or COPYING files are available
- `osps-qa-02-01`: Source code contains direct dependency list
- `osps-qa-05-01`: No generated executable artifacts in VCS
- `osps-qa-05-02`: No unreviewable binary artifacts in VCS

REST-based rules that call GitHub-specific API endpoints retain their context block to document the provider dependency.
Supersedes #401. Refs mindersec/minder#6481.