### PR TITLE
feat: add GitLab provider rule types for OSPS level-1 security baseline

### DIFF
--- a/security-baseline/rule-types/gitlab/osps-ac-02-01.yaml
+++ b/security-baseline/rule-types/gitlab/osps-ac-02-01.yaml
@@ -1,0 +1,39 @@
+version: v1
+release_phase: alpha
+type: rule-type
+name: osps-ac-02-01
+display_name: Default collaborators to lowest privileges
+short_failure_message: Collaborators default to privileged access
+severity:
+  value: info
+context:
+  provider: gitlab
+description: Verifies that project collaborators default to the lowest access level.
+guidance: |
+  Reduce the risk of unauthorized access to the project's repository
+  by limiting the permissions granted to collaborators.
+  Most public version control systems (such as GitLab) are configured
+  in this manner.
+
+  Note: GitLab's "internal" visibility (visible to all authenticated
+  instance users) is treated the same as "private" by this rule, since
+  it still restricts access beyond the general public.
+def:
+  in_entity: repository
+  rule_schema: {}
+  ingest:
+    type: rest
+    rest:
+      endpoint: '/projects/{{.Entity.RepoId}}'
+      parse: json
+      fallback:
+        - http_code: 404
+          body: |
+            {"http_status": 404, "message": "Repo not found"}
+  eval:
+    type: jq
+    jq:
+      # Public projects on GitLab will already have minimum _default_ permissions.
+      - ingested:
+          def: ".visibility"
+        constant: "public"

--- a/security-baseline/rule-types/gitlab/osps-ac-02-01.yaml
+++ b/security-baseline/rule-types/gitlab/osps-ac-02-01.yaml
@@ -6,8 +6,6 @@ display_name: Default collaborators to lowest privileges
 short_failure_message: Collaborators default to privileged access
 severity:
   value: info
-context:
-  provider: gitlab
 description: Verifies that project collaborators default to the lowest access level.
 guidance: |
   Reduce the risk of unauthorized access to the project's repository

--- a/security-baseline/rule-types/gitlab/osps-br-03-01.yaml
+++ b/security-baseline/rule-types/gitlab/osps-br-03-01.yaml
@@ -6,8 +6,6 @@ display_name: Development resources use secure channels
 short_failure_message: Insecure access to VCS
 severity:
   value: info
-context:
-  provider: gitlab
 description: Verifies that websites and version control systems for development use secure channels.
 guidance: |
   Any websites and version control systems involved in the project

--- a/security-baseline/rule-types/gitlab/osps-br-03-01.yaml
+++ b/security-baseline/rule-types/gitlab/osps-br-03-01.yaml
@@ -1,0 +1,41 @@
+version: v1
+release_phase: alpha
+type: rule-type
+name: osps-br-03-01
+display_name: Development resources use secure channels
+short_failure_message: Insecure access to VCS
+severity:
+  value: info
+context:
+  provider: gitlab
+description: Verifies that websites and version control systems for development use secure channels.
+guidance: |
+  Any websites and version control systems involved in the project
+  development MUST be delivered using SSH, HTTPS, or other encrypted
+  channels.
+
+  GitLab does this by default.
+def:
+  in_entity: repository
+  rule_schema: {}
+  ingest:
+    type: rest
+    rest:
+      endpoint: '/projects/{{.Entity.RepoId}}'
+      parse: json
+      fallback:
+        - http_code: 404
+          body: |
+            {"http_status": 404, "message": "Repo not found"}
+  eval:
+    type: rego
+    rego:
+      type: deny-by-default
+      def: |
+        package minder
+
+        import rego.v1
+
+        default allow := false
+
+        allow if startswith(input.ingested.http_url_to_repo, "https://")

--- a/security-baseline/rule-types/gitlab/osps-do-02-01.yaml
+++ b/security-baseline/rule-types/gitlab/osps-do-02-01.yaml
@@ -6,8 +6,6 @@ display_name: Public feedback mechanism supported
 short_failure_message: No public feedback mechanism found
 severity:
   value: medium
-context:
-  provider: gitlab
 description: |
   Ensures that public feedback via GitLab issues is available for users
   of the software, allowing them to report bugs and suggest improvements.

--- a/security-baseline/rule-types/gitlab/osps-do-02-01.yaml
+++ b/security-baseline/rule-types/gitlab/osps-do-02-01.yaml
@@ -1,0 +1,46 @@
+version: v1
+release_phase: alpha
+type: rule-type
+name: osps-do-02-01
+display_name: Public feedback mechanism supported
+short_failure_message: No public feedback mechanism found
+severity:
+  value: medium
+context:
+  provider: gitlab
+description: |
+  Ensures that public feedback via GitLab issues is available for users
+  of the software, allowing them to report bugs and suggest improvements.
+guidance: |
+  Ensure that issues are enabled on the repository, and that users can
+  view issues and find reports from other users.
+
+  Note: GitLab does not have a "Discussions" feature equivalent to
+  GitHub. Only issue tracker availability is checked here.
+
+  This rule will not currently detect the usage of an external feedback
+  system (for example, Jira or Trello).
+def:
+  in_entity: repository
+  rule_schema: {}
+  ingest:
+    type: rest
+    rest:
+      endpoint: '/projects/{{.Entity.RepoId}}'
+      parse: json
+      fallback:
+        - http_code: 404
+          body: |
+            {"http_status": 404, "message": "Repo not found"}
+  eval:
+    type: rego
+    rego:
+      type: deny-by-default
+      def: |
+        package minder
+
+        import rego.v1
+
+        default allow := false
+
+        allow if input.ingested.issues_enabled

--- a/security-baseline/rule-types/gitlab/osps-gv-02-01.yaml
+++ b/security-baseline/rule-types/gitlab/osps-gv-02-01.yaml
@@ -1,0 +1,46 @@
+version: v1
+release_phase: alpha
+type: rule-type
+name: osps-gv-02-01
+display_name: The project has mechanisms for public discussion
+short_failure_message: The project does not publicize mechanisms for public discussion.
+severity:
+  value: info
+context:
+  provider: gitlab
+description: |
+  Projects should encourage open communication and collaboration
+  within their community, enabling users to provide feedback and
+  discuss proposed changes or usage challenges.
+guidance: |
+  Enable "Issues" via the
+  [Settings](https://docs.gitlab.com/user/project/settings/)
+  page on GitLab.
+
+  Note: GitLab does not have a standalone "Discussions" feature
+  equivalent to GitHub. Issue tracker availability is used as the
+  proxy for public discussion mechanisms.
+def:
+  in_entity: repository
+  rule_schema: {}
+  ingest:
+    type: rest
+    rest:
+      endpoint: '/projects/{{.Entity.RepoId}}'
+      parse: json
+      fallback:
+        - http_code: 404
+          body: |
+            {"http_status": 404, "message": "Repo not found"}
+  eval:
+    type: rego
+    rego:
+      type: deny-by-default
+      def: |
+        package minder
+
+        import rego.v1
+
+        default allow := false
+
+        allow if input.ingested.issues_enabled

--- a/security-baseline/rule-types/gitlab/osps-gv-02-01.yaml
+++ b/security-baseline/rule-types/gitlab/osps-gv-02-01.yaml
@@ -6,8 +6,6 @@ display_name: The project has mechanisms for public discussion
 short_failure_message: The project does not publicize mechanisms for public discussion.
 severity:
   value: info
-context:
-  provider: gitlab
 description: |
   Projects should encourage open communication and collaboration
   within their community, enabling users to provide feedback and

--- a/security-baseline/rule-types/gitlab/osps-qa-01-01.yaml
+++ b/security-baseline/rule-types/gitlab/osps-qa-01-01.yaml
@@ -6,8 +6,6 @@ display_name: The project's source code is publicly readable
 short_failure_message: The project's source code is not publicly readable.
 severity:
   value: info
-context:
-  provider: gitlab
 description: |
   Enable users to access and review the project's source code and
   history, promoting transparency and collaboration within the project

--- a/security-baseline/rule-types/gitlab/osps-qa-01-01.yaml
+++ b/security-baseline/rule-types/gitlab/osps-qa-01-01.yaml
@@ -1,0 +1,45 @@
+version: v1
+release_phase: alpha
+type: rule-type
+name: osps-qa-01-01
+display_name: The project's source code is publicly readable
+short_failure_message: The project's source code is not publicly readable.
+severity:
+  value: info
+context:
+  provider: gitlab
+description: |
+  Enable users to access and review the project's source code and
+  history, promoting transparency and collaboration within the project
+  community.
+guidance: |
+  Change repository visibility via the
+  [Settings](https://docs.gitlab.com/user/public_access/)
+  page on GitLab.
+def:
+  in_entity: repository
+  rule_schema: {}
+  ingest:
+    type: rest
+    rest:
+      endpoint: '/projects/{{.Entity.RepoId}}'
+      parse: json
+      fallback:
+        - http_code: 404
+          body: |
+            {"http_status": 404, "message": "Repo not found"}
+  eval:
+    type: rego
+    rego:
+      type: deny-by-default
+      def: |
+        package minder
+
+        import rego.v1
+
+        default allow := false
+
+        allow if {
+          input.ingested.visibility == "public"
+          input.ingested.http_url_to_repo != ""
+        }


### PR DESCRIPTION
## Summary

Ports 5 of 11 REST-based OSPS level-1 rules to the GitLab provider, adding
a new `security-baseline/rule-types/gitlab/` directory mirroring the existing
`github/` structure.

## Rules added

| Rule ID | Description | GitLab API field |
|---------|-------------|-----------------|
| osps-ac-02-01 | Default collaborators to lowest privileges | `visibility == "public"` |
| osps-br-03-01 | Development resources use secure channels | `http_url_to_repo` starts with `https://` |
| osps-qa-01-01 | Source code is publicly readable | `visibility == "public"` + `http_url_to_repo` present |
| osps-do-02-01 | Public feedback mechanism supported | `issues_enabled` |
| osps-gv-02-01 | Project has mechanisms for public discussion | `issues_enabled` |

All rules ingest from `GET /projects/{{.Entity.RepoId}}` and were validated
end-to-end against a live GitLab project using a local Minder stack.

## Notes

- GitLab has a third visibility tier (`internal`) not present in GitHub. Rules
  treating `internal` the same as `private` is documented in guidance text.
- GitLab has no "Discussions" feature equivalent to GitHub — `osps-do-02-01`
  and `osps-gv-02-01` use `issues_enabled` as the proxy, with this gap noted
  in guidance.

## Remaining rules (follow-up PRs)

6 rules require deeper GitLab API work:
- `osps-ac-03-01`, `osps-ac-03-02`, `osps-qa-01-02` — branch protection (Protected Branches API)
- `osps-le-02-01` — license check (requires `?license=true` param)
- `osps-le-02-02`, `osps-le-03-02` — release asset checks

Fixes part of https://github.com/mindersec/minder/issues/6435