### PR TITLE
feat: add GitLab branch protection and change history OSPS rules

### DIFF
--- a/security-baseline/rule-types/gitlab/osps-ac-03-01.yaml
+++ b/security-baseline/rule-types/gitlab/osps-ac-03-01.yaml
@@ -1,0 +1,46 @@
+version: v1
+release_phase: alpha
+type: rule-type
+name: osps-ac-03-01
+display_name: Prevent overwriting git history
+short_failure_message: Force pushes are allowed
+severity:
+  value: info
+description: Disallow force pushes to the default branch
+guidance: |
+  Ensure that force pushes are disabled for the default branch
+  protection rule.
+
+  This setting prevents users with push access from force pushing
+  to the branch, preserving the integrity of the commit history.
+
+  For more information, see GitLab's documentation on
+  protected branches: https://docs.gitlab.com/user/project/protected_branches/
+def:
+  in_entity: repository
+  rule_schema: {}
+  ingest:
+    type: rest
+    rest:
+      endpoint: '/projects/{{.Entity.RepoId}}/protected_branches/{{.Entity.DefaultBranch}}'
+      parse: json
+      fallback:
+        - http_code: 404
+          body: |
+            {"http_status": 404, "message": "Not Protected"}
+  eval:
+    type: rego
+    rego:
+      type: deny-by-default
+      def: |
+        package minder
+
+        import rego.v1
+
+        default allow := false
+
+        msg := "Force pushes are allowed on the default branch"
+
+        allow if {
+          input.ingested.allow_force_push == false
+        }

--- a/security-baseline/rule-types/gitlab/osps-qa-01-02.yaml
+++ b/security-baseline/rule-types/gitlab/osps-qa-01-02.yaml
@@ -1,0 +1,44 @@
+version: v1
+release_phase: alpha
+type: rule-type
+name: osps-qa-01-02
+display_name: Maintain publicly readable change history
+short_failure_message: Repository must be public and prevent force pushes
+severity:
+  value: info
+description: |
+  Ensure that the project's change history is publicly readable and
+  cannot be overwritten, maintaining transparency and trust in the
+  development process.
+guidance: |
+  1. Make sure the repository is public via GitLab's
+     repository visibility settings.
+  2. Ensure force pushes are disabled via the protected branches
+     settings for the default branch.
+def:
+  in_entity: repository
+  rule_schema: {}
+  ingest:
+    type: rest
+    rest:
+      endpoint: '/projects/{{.Entity.RepoId}}/protected_branches/{{.Entity.DefaultBranch}}'
+      parse: json
+      fallback:
+        - http_code: 404
+          body: |
+            {"http_status": 404, "message": "Not Protected"}
+  eval:
+    type: rego
+    rego:
+      type: deny-by-default
+      def: |
+        package minder
+
+        import rego.v1
+
+        default allow := false
+
+        allow if {
+          not input.properties.is_private
+          input.ingested.allow_force_push == false
+        }


### PR DESCRIPTION
## Summary

Adds 2 more GitLab OSPS level-1 rule types, continuing the work from #412.

## Rules added

| Rule ID | Description | GitLab API | Endpoint |
|---------|-------------|------------|----------|
| osps-ac-03-01 | Prevent overwriting git history | `allow_force_push == false` | `GET /projects/:id/protected_branches/:branch` |
| osps-qa-01-02 | Maintain publicly readable change history | `is_private == false` + `allow_force_push == false` | `GET /projects/:id/protected_branches/:branch` |

Both rules validated end-to-end against live GitLab projects using a local Minder stack.

## Notes

- GitLab's Protected Branches API returns `allow_force_push` as a direct boolean — simpler than GitHub's equivalent which also requires checking rulesets via a data source
- `osps-ac-03-02` (prevent branch deletion) is **not included** — GitLab doesn't have a direct `allow_deletions` boolean equivalent. Branch deletion protection in GitLab is controlled through `unprotect_access_levels` semantics which differ meaningfully from GitHub's model. Flagging for discussion before implementing.

## Part of

Continues GitLab OSPS level-1 rule porting — part of mindersec/minder#6435